### PR TITLE
Removed Singleton pattern from OmiseAccount & OmiseBalance lib.

### DIFF
--- a/lib/omise/OmiseAccount.php
+++ b/lib/omise/OmiseAccount.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResourceSingleton.php';
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
-class OmiseAccount extends OmiseApiResourceSingleton {
+class OmiseAccount extends OmiseApiResource {
   const ENDPOINT = 'account';
 
   /**

--- a/lib/omise/OmiseBalance.php
+++ b/lib/omise/OmiseBalance.php
@@ -1,8 +1,8 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResourceSingleton.php';
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
-class OmiseBalance extends OmiseApiResourceSingleton {
+class OmiseBalance extends OmiseApiResource {
   const ENDPOINT = 'balance';
 
   /**

--- a/tests/omise/AccountTest.php
+++ b/tests/omise/AccountTest.php
@@ -39,17 +39,6 @@ class OmiseAccountTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('account', $account['object']);
   }
 
-  /**
-   * ----- Test singleton -----
-   * Assert that retrieving the account twice returns the same instance.
-   */
-  public function testSameInstance() {
-    $account1 = OmiseAccount::retrieve();
-    $account2 = OmiseAccount::retrieve();
-
-    $this->assertTrue($account1 === $account2);
-  }
-
   public function tearDown() {
     /** Do Nothing **/
   }

--- a/tests/omise/BalanceTest.php
+++ b/tests/omise/BalanceTest.php
@@ -39,17 +39,6 @@ class OmiseBalanceTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('balance', $balance['object']);
   }
 
-  /**
-   * ----- Test singleton -----
-   * Assert that retrieving the balance twice returns the same instance.
-   */
-  public function testSameInstance() {
-    $balance1 = OmiseBalance::retrieve();
-    $balance2 = OmiseBalance::retrieve();
-
-    $this->assertTrue($balance1 === $balance2);
-  }
-
   public function tearDown() {
     /** Do Nothing **/
   }


### PR DESCRIPTION
Removed singleton pattern from OmiseAccount & OmiseBalance  service.
It will fail if use OmiseAccount & OmiseBalance in the same time.