### PR TITLE
Bump release to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 # Change Log
 
-An [unreleased] version is not available on `master` branch and is subject to changes and must not be considered final. Elements of unreleased list may be edited or removed at any time.
-
-## [unreleased]
-- [Addde] Add Omise-Version header to request.
-- [Addde] Add `OMISE_USER_AGENT_SUFFIX` constant that let's people add the suffix into the `user-agent` string.
+## [2.4.0] 2015-11-13
+- [Added] Add Omise-Version header to request.
+- [Added] Add `OMISE_USER_AGENT_SUFFIX` constant that let's people add the suffix into the `user-agent` string.
 
 ## [2.3.2] 2015-09-30
 - [Fixed] Pass key values into the OmiseRefundList object when call a refunds() method inside the OmiseCharge instance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
-An [unreleased] version is not available on `master` branch. Elements of unreleased list may be edited or removed at any time.
+An [unreleased] version is not available on `master` branch and is subject to changes and must not be considered final. Elements of unreleased list may be edited or removed at any time.
+
+## [unreleased]
+- [Addde] Add Omise-Version header to request.
+- [Addde] Add `OMISE_USER_AGENT_SUFFIX` constant that let's people add the suffix into the `user-agent` string.
 
 ## [2.3.2] 2015-09-30
 - [Fixed] Pass key values into the OmiseRefundList object when call a refunds() method inside the OmiseCharge instance.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,23 @@ require_once dirname(__FILE__).'/omise-php/lib/Omise.php';
 
 Please see usage section below for usage examples.
 
+### API version
+
+In case you want to enforce API version the application use, you can specify it
+by setting the api_version. The version specified by this settings will override
+the version setting in your account. This is useful if you have multiple
+environments with different API versions (e.g. development on the latest but
+production on the older version).
+
+```php
+require_once dirname(__FILE__).'/omise-php/lib/Omise.php';
+
+define('OMISE_API_VERSION', '2014-07-27');
+```
+
+It is highly recommended to set this version to the current version
+you're using.
+
 ## Usage
 
 ### 1. Flow

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -3,7 +3,7 @@
 require_once dirname(__FILE__).'/obj/OmiseObject.php';
 require_once dirname(__FILE__).'/../exception/OmiseExceptions.php';
 
-define('OMISE_PHP_LIB_VERSION', '2.3.2');
+define('OMISE_PHP_LIB_VERSION', '2.4.0');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -4,7 +4,6 @@ require_once dirname(__FILE__).'/obj/OmiseObject.php';
 require_once dirname(__FILE__).'/../exception/OmiseExceptions.php';
 
 define('OMISE_PHP_LIB_VERSION', '2.3.2');
-define('OMISE_API_VERSION', '2014-07-27');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
@@ -208,13 +207,14 @@ class OmiseApiResource extends OmiseObject {
    * @return array
    */
   private function genOptions($requestMethod, $userpwd, $params) {
+    $user_agent = "OmisePHP/".OMISE_PHP_LIB_VERSION;
+    $omise_api_version = defined('OMISE_API_VERSION') ? OMISE_API_VERSION : null;
+
     $options = array(
         // Set the HTTP version to 1.1.
         CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
         // Set the request method.
         CURLOPT_CUSTOMREQUEST => $requestMethod,
-        // Set the user agent.
-        CURLOPT_USERAGENT => "OmisePHP/".OMISE_PHP_LIB_VERSION." OmiseAPI/".OMISE_API_VERSION,
         // Make php-curl returns the data as string.
         CURLOPT_RETURNTRANSFER => true,
         // Do not include the header in the output.
@@ -233,6 +233,19 @@ class OmiseApiResource extends OmiseObject {
         // CA bundle.
         CURLOPT_CAINFO => dirname(__FILE__).'/../../../data/ca_certificates.pem'
     );
+
+    // Config Omise API Version
+    if ($omise_api_version) {
+      $options += array(CURLOPT_HTTPHEADER => array("Omise-Version: ".$omise_api_version));
+
+      $user_agent .= ' OmiseAPI/'.$omise_api_version;
+    }
+
+    // Config UserAgent
+    if (defined('OMISE_USER_AGENT_SUFFIX'))
+      $options += array(CURLOPT_USERAGENT => $user_agent." ".OMISE_USER_AGENT_SUFFIX);
+    else
+      $options += array(CURLOPT_USERAGENT => $user_agent);
 
     // Also merge POST parameters with the option.
     if(count($params) > 0) $options += array(CURLOPT_POSTFIELDS => http_build_query($params));


### PR DESCRIPTION
## PR Purpose
Bump release to 2.4.0

The things that improved are as follows:
- [Added] Add Omise-Version header to request.
- [Added] Add `OMISE_USER_AGENT_SUFFIX` constant that let's people add the suffix into the `user-agent` string.