### PR TITLE
Add fetch options to customer cards

### DIFF
--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -13,10 +13,19 @@ class OmiseCardList extends OmiseApiResource {
    * @param string $publickey
    * @param string $secretkey
    */
-  public function __construct($cards, $customerID, $publickey = null, $secretkey = null) {
+  public function __construct($cards, $customerID, $options = array(), $publickey = null, $secretkey = null) {
+    if (!is_array($options) && func_num_args() == 4) {
+      $publickey = func_get_arg(2);
+      $secretkey = func_get_arg(3);
+    }
+
     parent::__construct($publickey, $secretkey);
     $this->_customerID = $customerID;
-    $this->refresh($cards);
+
+    if (is_array($options))
+      parent::g_reload($this->getUrl('?'. http_build_query($options)));
+    else
+      $this->refresh($cards);
   }
   
   /**

--- a/lib/omise/OmiseCustomer.php
+++ b/lib/omise/OmiseCustomer.php
@@ -68,8 +68,10 @@ class OmiseCustomer extends OmiseApiResource {
    * Gets a list of all cards belongs to this customer.
    * @return OmiseCardList
    */
-  public function cards() {
-    if($this['object'] === 'customer') {
+  public function cards($options = array()) {
+    if($this['object'] === 'customer' &&  !empty($options)) {
+      return new OmiseCardList($this['cards'], $this['id'], $options, $this->_publickey, $this->_secretkey);
+    } else if ($this['object'] === 'customer') {
       return new OmiseCardList($this['cards'], $this['id'], $this->_publickey, $this->_secretkey);
     }
   }
@@ -79,8 +81,8 @@ class OmiseCustomer extends OmiseApiResource {
    * @deprecated deprecated since version 2.0.0 use '$customer->cards()'
    * @return OmiseCardList
    */
-  public function getCards() {
-    return $this->cards();
+  public function getCards($options = array()) {
+    return $this->cards($options);
   }
 
   /**

--- a/tests/fixtures/api.omise.co/customers/cust_test_5234fzk37pi2mz0cen3-get.json
+++ b/tests/fixtures/api.omise.co/customers/cust_test_5234fzk37pi2mz0cen3-get.json
@@ -1,0 +1,59 @@
+{
+  "object": "customer",
+  "id": "cust_test_5234fzk37pi2mz0cen3",
+  "livemode": false,
+  "location": "/customers/cust_test_5234fzk37pi2mz0cen3",
+  "default_card": "card_test_5234g4ctbewk18nwvvq",
+  "email": "johndoe@example.com",
+  "description": "New description",
+  "created": "2015-11-20T08:35:47Z",
+  "cards": {
+    "object": "list",
+    "from": "1970-01-01T00:00:00+00:00",
+    "to": "2015-12-03T09:04:20+00:00",
+    "offset": 0,
+    "limit": 20,
+    "total": 2,
+    "data": [
+      {
+        "object": "card",
+        "id": "card_test_5234fx4wnf5ygnlp1p6",
+        "livemode": false,
+        "location": "/customers/cust_test_5234fzk37pi2mz0cen3/cards/card_test_5234fx4wnf5ygnlp1p6",
+        "country": "us",
+        "city": "Bangkok",
+        "postal_code": "10320",
+        "financing": "",
+        "bank": "",
+        "last_digits": "4242",
+        "brand": "Visa",
+        "expiration_month": 11,
+        "expiration_year": 2017,
+        "fingerprint": "b7ETDh/GD7EcJvppdJWZICfDs5QsvCJCXBkWHTJCCGc=",
+        "name": "JOHN DOE",
+        "security_code_check": true,
+        "created": "2015-11-20T08:35:36Z"
+      },
+      {
+        "object": "card",
+        "id": "card_test_5234g4ctbewk18nwvvq",
+        "livemode": false,
+        "location": "/customers/cust_test_5234fzk37pi2mz0cen3/cards/card_test_5234g4ctbewk18nwvvq",
+        "country": "us",
+        "city": "Bangkok",
+        "postal_code": "10320",
+        "financing": "",
+        "bank": "",
+        "last_digits": "4242",
+        "brand": "Visa",
+        "expiration_month": 11,
+        "expiration_year": 2017,
+        "fingerprint": "b7ETDh/GD7EcJvppdJWZICfDs5QsvCJCXBkWHTJCCGc=",
+        "name": "JOHN DOE",
+        "security_code_check": true,
+        "created": "2015-11-20T08:36:10Z"
+      }
+    ],
+    "location": "/customers/cust_test_5234fzk37pi2mz0cen3/cards"
+  }
+}

--- a/tests/fixtures/api.omise.co/customers/cust_test_5234fzk37pi2mz0cen3/cards/?limit=1-get.json
+++ b/tests/fixtures/api.omise.co/customers/cust_test_5234fzk37pi2mz0cen3/cards/?limit=1-get.json
@@ -1,0 +1,29 @@
+{
+  "object": "list",
+  "from": "1970-01-01T00:00:00+00:00",
+  "to": "2015-12-03T09:04:20+00:00",
+  "offset": 0,
+  "limit": 1,
+  "total": 2,
+  "data": [
+    {
+      "object": "card",
+      "id": "card_test_5234fx4wnf5ygnlp1p6",
+      "livemode": false,
+      "location": "/customers/cust_test_5234fzk37pi2mz0cen3/cards/card_test_5234fx4wnf5ygnlp1p6",
+      "country": "us",
+      "city": "Bangkok",
+      "postal_code": "10320",
+      "financing": "",
+      "bank": "",
+      "last_digits": "4242",
+      "brand": "Visa",
+      "expiration_month": 11,
+      "expiration_year": 2017,
+      "fingerprint": "b7ETDh/GD7EcJvppdJWZICfDs5QsvCJCXBkWHTJCCGc=",
+      "name": "JOHN DOE",
+      "security_code_check": true,
+      "created": "2015-11-20T08:35:36Z"
+    }
+  ]
+}

--- a/tests/omise/CustomerTest.php
+++ b/tests/omise/CustomerTest.php
@@ -53,6 +53,23 @@ class CustomerTest extends TestConfig {
   }
 
   /**
+   * Assert that a customer object is returned after a successful retrieve.
+   *
+   */
+  public function testRetrieveCardObjectFromCustomer() {
+    $customer = OmiseCustomer::retrieve('cust_test_5234fzk37pi2mz0cen3');
+    $cards    = $customer->cards(array('limit' => 1));
+
+    $this->assertArrayHasKey('object', $cards);
+    $this->assertEquals('list', $cards['object']);
+
+    if (!empty($cards['data'])) {
+      $this->assertEquals('card', $cards['data'][0]['object']);
+      $this->assertEquals(1, count($cards['data']));
+    }
+  }
+
+  /**
    * Assert that a customer is successfully updated with the given parameters set.
    *
    */


### PR DESCRIPTION
## PR Purpose
Passing an options array to the cards() method of the customer class will initiate a new
request to re-fetch the cards by passing the options array as query parameters.

This let you for example fetch the cards in chronological order:
```php
$customer = OmiseCustomer::retrieve('cust_test');
$cards = $customer->cards(array(
  'order' => 'chronological'
);
```
Or any of the other filtering attributes: from, to, offset, limit.