### PR TITLE
Change condition when matching phpunit from using fixed string to regex

### DIFF
--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -111,7 +111,7 @@ class OmiseApiResource extends OmiseObject {
   protected function execute($url, $requestMethod, $key, $params = null) {
 
     // If this class is execute by phpunit > get test mode.
-    if ($_SERVER['SCRIPT_NAME'] == "./vendor/bin/phpunit") {
+    if (preg_match('/phpunit/', $_SERVER['SCRIPT_NAME'])) {
       $result = $this->_executeTest($url, $requestMethod, $key, $params);
     } else {
       $result = $this->_executeCurl($url, $requestMethod, $key, $params);


### PR DESCRIPTION
This pull request fix a path matching when testing in local machine.

Because sometimes developer use a `phpunit` to run the script, which `$_SERVER['SCRIPT_NAME']` will be resolved to `phpunit`, so the `$_SERVER['SCRIPT_NAME'] == "./vendor/bin/phpunit"` will not match anything and the test will attempt to call the real API.