### PR TITLE
Autoload OmiseDispute class in lib/Omise.php file

### DIFF
--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -4,6 +4,7 @@ require_once dirname(__FILE__).'/omise/OmiseAccount.php';
 require_once dirname(__FILE__).'/omise/OmiseBalance.php';
 require_once dirname(__FILE__).'/omise/OmiseCard.php';
 require_once dirname(__FILE__).'/omise/OmiseCardList.php';
+require_once dirname(__FILE__).'/omise/OmiseDispute.php';
 require_once dirname(__FILE__).'/omise/OmiseEvent.php';
 require_once dirname(__FILE__).'/omise/OmiseToken.php';
 require_once dirname(__FILE__).'/omise/OmiseCharge.php';

--- a/tests/omise/ClassExistsTest.php
+++ b/tests/omise/ClassExistsTest.php
@@ -1,0 +1,39 @@
+<?php
+define('OMISE_PUBLIC_KEY', 'pkey');
+define('OMISE_SECRET_KEY', 'skey');
+
+require_once dirname(__FILE__).'/../../lib/Omise.php';
+
+class ClassExistsTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * All classes in lib folder should be loaded inside lib/Omise.php.
+     */
+    public function testAPIClassesExists()
+    {
+        $this->assertTrue(class_exists('OmiseAccount'));
+        $this->assertTrue(class_exists('OmiseBalance'));
+        $this->assertTrue(class_exists('OmiseCard'));
+        $this->assertTrue(class_exists('OmiseCardList'));
+        $this->assertTrue(class_exists('OmiseCharge'));
+        $this->assertTrue(class_exists('OmiseCustomer'));
+        $this->assertTrue(class_exists('OmiseDispute'));
+        $this->assertTrue(class_exists('OmiseRecipient'));
+        $this->assertTrue(class_exists('OmiseRefund'));
+        $this->assertTrue(class_exists('OmiseRefundList'));
+        $this->assertTrue(class_exists('OmiseToken'));
+        $this->assertTrue(class_exists('OmiseTransaction'));
+        $this->assertTrue(class_exists('OmiseTransfer'));
+    }
+
+    /**
+     * All resource classes should be loaded.
+     */
+    public function testResourceClassesExists()
+    {
+        $this->assertTrue(class_exists('OmiseApiResource'));
+        $this->assertTrue(class_exists('OmiseVaultResource'));
+        $this->assertTrue(class_exists('OmiseObject'));
+        $this->assertTrue(class_exists('OmiseException'));
+    }
+}

--- a/tests/omise/ClassExistsTest.php
+++ b/tests/omise/ClassExistsTest.php
@@ -18,6 +18,7 @@ class ClassExistsTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(class_exists('OmiseCharge'));
         $this->assertTrue(class_exists('OmiseCustomer'));
         $this->assertTrue(class_exists('OmiseDispute'));
+        $this->assertTrue(class_exists('OmiseEvent'));
         $this->assertTrue(class_exists('OmiseRecipient'));
         $this->assertTrue(class_exists('OmiseRefund'));
         $this->assertTrue(class_exists('OmiseRefundList'));


### PR DESCRIPTION
**1. Objective reason**

Add missing OmiseDispute class from autoload file.

**2. Description of change**
- Update `lib/Omise.php` 1 line to require `OmiseDispute` class when file be loaded
- Add test according to changed.

**3. Users affected by the change**

No

**4. Impact of the change**

No

**5. Priority of change**

Normal

**6. Alternate solution**

No
