### PR TITLE
OmiseRecipient object be able to reload itself resource

### DIFF
--- a/lib/omise/OmiseRecipient.php
+++ b/lib/omise/OmiseRecipient.php
@@ -65,6 +65,20 @@ class OmiseRecipient extends OmiseApiResource
     }
 
     /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        if ($this['object'] === 'recipient') {
+            parent::g_reload(self::getUrl($this['id']));
+        } else {
+            parent::g_reload(self::getUrl());
+        }
+    }
+
+    /**
      * @param  string $id
      *
      * @return string


### PR DESCRIPTION
**1. Objective reason**

Now, it's be able to reload itself resource by calling 
```php
$recipient = OmiseRecipient::retrieve();
$recipient->reload();
```

**2. Description of change**
- Implement `reload()` method to `OmiseRecipient.php`.

**3. Users affected by the change**

No

**4. Impact of the change**

No

**5. Priority of change**

Normal

**6. Alternate solution**

No
