### PR TITLE
Add namespace to all Omise classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,6 @@
     "phpunit/phpunit": "4.4.*"
   },
   "autoload": {
-    "classmap": ["lib/omise/"]
+    "classmap": ["lib/legacy/"]
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "phpunit/phpunit": "4.4.*"
   },
   "autoload": {
-    "classmap": ["lib/legacy/"]
+    "classmap": ["lib/legacy/"],
+    "psr-4": {
+      "Omise\\": "lib/omise/"
+    }
   }
 }

--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -1,7 +1,4 @@
 <?php
-/**
- * @deprecated 3.0.0 not recommended, please implement with namespace approach.
- */
 require_once dirname(__FILE__).'/legacy/OmiseAccount.php';
 require_once dirname(__FILE__).'/legacy/OmiseBalance.php';
 require_once dirname(__FILE__).'/legacy/OmiseCard.php';

--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -1,4 +1,7 @@
 <?php
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 require_once dirname(__FILE__).'/legacy/OmiseAccount.php';
 require_once dirname(__FILE__).'/legacy/OmiseBalance.php';
 require_once dirname(__FILE__).'/legacy/OmiseCard.php';

--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -1,16 +1,15 @@
 <?php
-
-require_once dirname(__FILE__).'/omise/OmiseAccount.php';
-require_once dirname(__FILE__).'/omise/OmiseBalance.php';
-require_once dirname(__FILE__).'/omise/OmiseCard.php';
-require_once dirname(__FILE__).'/omise/OmiseCardList.php';
-require_once dirname(__FILE__).'/omise/OmiseDispute.php';
-require_once dirname(__FILE__).'/omise/OmiseEvent.php';
-require_once dirname(__FILE__).'/omise/OmiseToken.php';
-require_once dirname(__FILE__).'/omise/OmiseCharge.php';
-require_once dirname(__FILE__).'/omise/OmiseCustomer.php';
-require_once dirname(__FILE__).'/omise/OmiseRefund.php';
-require_once dirname(__FILE__).'/omise/OmiseRefundList.php';
-require_once dirname(__FILE__).'/omise/OmiseTransfer.php';
-require_once dirname(__FILE__).'/omise/OmiseTransaction.php';
-require_once dirname(__FILE__).'/omise/OmiseRecipient.php';
+require_once dirname(__FILE__).'/legacy/OmiseAccount.php';
+require_once dirname(__FILE__).'/legacy/OmiseBalance.php';
+require_once dirname(__FILE__).'/legacy/OmiseCard.php';
+require_once dirname(__FILE__).'/legacy/OmiseCardList.php';
+require_once dirname(__FILE__).'/legacy/OmiseDispute.php';
+require_once dirname(__FILE__).'/legacy/OmiseEvent.php';
+require_once dirname(__FILE__).'/legacy/OmiseToken.php';
+require_once dirname(__FILE__).'/legacy/OmiseCharge.php';
+require_once dirname(__FILE__).'/legacy/OmiseCustomer.php';
+require_once dirname(__FILE__).'/legacy/OmiseRefund.php';
+require_once dirname(__FILE__).'/legacy/OmiseRefundList.php';
+require_once dirname(__FILE__).'/legacy/OmiseTransfer.php';
+require_once dirname(__FILE__).'/legacy/OmiseTransaction.php';
+require_once dirname(__FILE__).'/legacy/OmiseRecipient.php';

--- a/lib/legacy/OmiseAccount.php
+++ b/lib/legacy/OmiseAccount.php
@@ -1,0 +1,41 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseAccount extends OmiseApiResource
+{
+    const ENDPOINT = 'account';
+
+    /**
+     * Retrieves an account.
+     *
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseAccount
+     */
+    public static function retrieve($publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl(), $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        parent::g_reload(self::getUrl());
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseAccount.php
+++ b/lib/legacy/OmiseAccount.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseAccount extends OmiseApiResource
 {
     const ENDPOINT = 'account';

--- a/lib/legacy/OmiseBalance.php
+++ b/lib/legacy/OmiseBalance.php
@@ -1,0 +1,41 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseBalance extends OmiseApiResource
+{
+    const ENDPOINT = 'balance';
+
+    /**
+     * Retrieves a current balance in the account.
+     *
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseBalance
+     */
+    public static function retrieve($publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl(), $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        parent::g_reload(self::getUrl());
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseBalance.php
+++ b/lib/legacy/OmiseBalance.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseBalance extends OmiseApiResource
 {
     const ENDPOINT = 'balance';

--- a/lib/legacy/OmiseCard.php
+++ b/lib/legacy/OmiseCard.php
@@ -1,0 +1,77 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+require_once dirname(__FILE__).'/OmiseCustomer.php';
+
+class OmiseCard extends OmiseApiResource
+{
+    const ENDPOINT = 'cards';
+
+    private $_customerID;
+
+    /**
+     * Object representing a card. Cards are retrieved using a `Customer`.
+     *
+     * @param array  $array
+     * @param string $customerID
+     * @param string $publickey
+     * @param string $secretkey
+     */
+    public function __construct($array, $customerID, $publickey = null, $secretkey = null)
+    {
+        parent::__construct($publickey, $secretkey);
+
+        $this->_customerID = $customerID;
+        $this->refresh($array);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        parent::g_reload($this->getUrl($this['id']));
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_update()
+     */
+    public function update($params)
+    {
+        parent::g_update($this->getUrl($this['id']), $params);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_destroy()
+     */
+    public function destroy()
+    {
+        parent::g_destroy($this->getUrl($this['id']));
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::isDestroyed()
+     */
+    public function isDestroyed()
+    {
+        return parent::isDestroyed();
+    }
+
+    /**
+     * @param  string $cardID
+     *
+     * @return string
+     */
+    private function getUrl($cardID = '')
+    {
+        return OMISE_API_URL.OmiseCustomer::ENDPOINT.'/'.$this->_customerID.'/'.self::ENDPOINT.'/'.$cardID;
+    }
+}

--- a/lib/legacy/OmiseCard.php
+++ b/lib/legacy/OmiseCard.php
@@ -3,6 +3,9 @@
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 require_once dirname(__FILE__).'/OmiseCustomer.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseCard extends OmiseApiResource
 {
     const ENDPOINT = 'cards';

--- a/lib/legacy/OmiseCardList.php
+++ b/lib/legacy/OmiseCardList.php
@@ -1,0 +1,59 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+require_once dirname(__FILE__).'/OmiseCard.php';
+
+class OmiseCardList extends OmiseApiResource
+{
+    const ENDPOINT = 'cards';
+
+    private $_customerID;
+  
+    /**
+     * @param array  $cards
+     * @param string $customerID
+     * @param string $publickey
+     * @param string $secretkey
+     */
+    public function __construct($cards, $customerID, $options = array(), $publickey = null, $secretkey = null)
+    {
+        if (! is_array($options) && func_num_args() == 4) {
+            $publickey = func_get_arg(2);
+            $secretkey = func_get_arg(3);
+        }
+
+        parent::__construct($publickey, $secretkey);
+        $this->_customerID = $customerID;
+
+        if (is_array($options)) {
+            parent::g_reload($this->getUrl('?'.http_build_query($options)));
+        } else {
+            $this->refresh($cards);
+        }
+    }
+  
+    /**
+     * retrieve a card
+     *
+     * @param  string $id
+     *
+     * @return OmiseCard
+     */
+    public function retrieve($id)
+    {
+        $result = parent::execute($this->getUrl($id), parent::REQUEST_GET, self::getResourceKey());
+
+        return new OmiseCard($result, $this->_customerID, $this->_publickey, $this->_secretkey);
+    }
+  
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private function getUrl($id = '')
+    {
+        return OMISE_API_URL.'customers/'.$this->_customerID.'/'.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseCardList.php
+++ b/lib/legacy/OmiseCardList.php
@@ -3,6 +3,9 @@
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 require_once dirname(__FILE__).'/OmiseCard.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseCardList extends OmiseApiResource
 {
     const ENDPOINT = 'cards';

--- a/lib/legacy/OmiseCharge.php
+++ b/lib/legacy/OmiseCharge.php
@@ -1,0 +1,109 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+require_once dirname(__FILE__).'/OmiseRefundList.php';
+
+class OmiseCharge extends OmiseApiResource
+{
+    const ENDPOINT = 'charges';
+
+    /**
+     * Retrieves a charge.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseCharge
+     */
+    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        if ($this['object'] === 'charge') {
+            parent::g_reload(self::getUrl($this['id']));
+        } else {
+            parent::g_reload(self::getUrl());
+        }
+    }
+
+    /**
+     * Creates a new charge.
+     *
+     * @param  array  $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseCharge
+     */
+    public static function create($params, $publickey = null, $secretkey = null)
+    {
+        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_update()
+     */
+    public function update($params)
+    {
+        parent::g_update(self::getUrl($this['id']), $params);
+    }
+
+    /**
+     * Captures a charge.
+     *
+     * @return OmiseCharge
+     */
+    public function capture()
+    {
+        $result = parent::execute(self::getUrl($this['id']).'/capture', parent::REQUEST_POST, parent::getResourceKey());
+        $this->refresh($result);
+
+        return $this;
+    }
+
+    /**
+     * Reverses a charge.
+     *
+     * @return OmiseCharge
+     */
+    public function reverse()
+    {
+        $result = parent::execute(self::getUrl($this['id']).'/reverse', parent::REQUEST_POST, parent::getResourceKey());
+        $this->refresh($result);
+
+        return $this;
+    }
+
+    /**
+     * list refunds
+     *
+     * @return OmiseRefundList
+     */
+    public function refunds()
+    {
+        $result = parent::execute(self::getUrl($this['id']).'/refunds', parent::REQUEST_GET, parent::getResourceKey());
+
+        return new OmiseRefundList($result, $this['id'], $this->_publickey, $this->_secretkey);
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseCharge.php
+++ b/lib/legacy/OmiseCharge.php
@@ -3,6 +3,9 @@
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 require_once dirname(__FILE__).'/OmiseRefundList.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseCharge extends OmiseApiResource
 {
     const ENDPOINT = 'charges';

--- a/lib/legacy/OmiseCustomer.php
+++ b/lib/legacy/OmiseCustomer.php
@@ -1,0 +1,119 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+require_once dirname(__FILE__).'/OmiseCardList.php';
+
+class OmiseCustomer extends OmiseApiResource
+{
+    const ENDPOINT = 'customers';
+
+    /**
+     * Retrieves a customer.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseCustomer
+     */
+    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * Creates a new customer.
+     *
+     * @param  array  $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseCustomer
+     */
+    public static function create($params, $publickey = null, $secretkey = null)
+    {
+        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        if ($this['object'] === 'customer') {
+            parent::g_reload(self::getUrl($this['id']));
+        } else {
+            parent::g_reload(self::getUrl());
+        }
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_update()
+     */
+    public function update($params)
+    {
+        parent::g_update(self::getUrl($this['id']), $params);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_destroy()
+     */
+    public function destroy()
+    {
+        parent::g_destroy(self::getUrl($this['id']));
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::isDestroyed()
+     */
+    public function isDestroyed()
+    {
+        return parent::isDestroyed();
+    }
+
+    /**
+     * Gets a list of all cards belongs to this customer.
+     *
+     * @param  array $options
+     *
+     * @return OmiseCardList
+     */
+    public function cards($options = array())
+    {
+        if ($this['object'] === 'customer' && ! empty($options)) {
+            return new OmiseCardList($this['cards'], $this['id'], $options, $this->_publickey, $this->_secretkey);
+        } else if ($this['object'] === 'customer') {
+            return new OmiseCardList($this['cards'], $this['id'], $this->_publickey, $this->_secretkey);
+        }
+    }
+  
+    /**
+     * cards() alias
+     *
+     * @deprecated deprecated since version 2.0.0 use '$customer->cards()'
+     *
+     * @return     OmiseCardList
+     */
+    public function getCards($options = array())
+    {
+        return $this->cards($options);
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseCustomer.php
+++ b/lib/legacy/OmiseCustomer.php
@@ -3,6 +3,9 @@
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 require_once dirname(__FILE__).'/OmiseCardList.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseCustomer extends OmiseApiResource
 {
     const ENDPOINT = 'customers';

--- a/lib/legacy/OmiseDispute.php
+++ b/lib/legacy/OmiseDispute.php
@@ -1,0 +1,58 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseDispute extends OmiseApiResource
+{
+    const ENDPOINT = 'disputes';
+
+    /**
+     * Retrieves a dispute.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseDispute
+     */
+    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        if ($this['object'] === 'dispute') {
+            parent::g_reload(self::getUrl($this['id']));
+        } else {
+            parent::g_reload(self::getUrl());
+        }
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_update()
+     */
+    public function update($params)
+    {
+        parent::g_update(self::getUrl($this['id']), $params);
+    }
+
+    /**
+     * Generate request url.
+     *
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseDispute.php
+++ b/lib/legacy/OmiseDispute.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseDispute extends OmiseApiResource
 {
     const ENDPOINT = 'disputes';

--- a/lib/legacy/OmiseEvent.php
+++ b/lib/legacy/OmiseEvent.php
@@ -1,0 +1,48 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseEvent extends OmiseApiResource
+{
+    const ENDPOINT = 'events';
+
+    /**
+     * Retrieves an event.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseEvent
+     */
+    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        if ($this['object'] === 'event') {
+            parent::g_reload(self::getUrl($this['id']));
+        } else {
+            parent::g_reload(self::getUrl());
+        }
+    }
+
+    /**
+     * Generate request url.
+     *
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseEvent.php
+++ b/lib/legacy/OmiseEvent.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseEvent extends OmiseApiResource
 {
     const ENDPOINT = 'events';

--- a/lib/legacy/OmiseRecipient.php
+++ b/lib/legacy/OmiseRecipient.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseRecipient extends OmiseApiResource
+{
+    const ENDPOINT = 'recipients';
+
+    /**
+     * Retrieves recipients.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseRecipient
+     */
+    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * Creates a new recipient.
+     *
+     * @param  array  $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseRecipient
+     */
+    public static function create($params, $publickey = null, $secretkey = null)
+    {
+        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_update()
+     */
+    public function update($params)
+    {
+        parent::g_update(self::getUrl($this['id']), $params);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_destroy()
+     */
+    public function destroy()
+    {
+        parent::g_destroy(self::getUrl($this['id']));
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::isDestroyed()
+     */
+    public function isDestroyed()
+    {
+        return parent::isDestroyed();
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseRecipient.php
+++ b/lib/legacy/OmiseRecipient.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseRecipient extends OmiseApiResource
 {
     const ENDPOINT = 'recipients';

--- a/lib/legacy/OmiseRefund.php
+++ b/lib/legacy/OmiseRefund.php
@@ -1,0 +1,17 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseRefund extends OmiseApiResource
+{
+    /**
+     * @param array  $refund
+     * @param string $publickey
+     * @param string $secretkey
+     */
+    public function __construct($refund, $publickey = null, $secretkey = null)
+    {
+        parent::__construct($publickey, $secretkey);
+        $this->refresh($refund);
+    }
+}

--- a/lib/legacy/OmiseRefund.php
+++ b/lib/legacy/OmiseRefund.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseRefund extends OmiseApiResource
 {
     /**

--- a/lib/legacy/OmiseRefundList.php
+++ b/lib/legacy/OmiseRefundList.php
@@ -1,0 +1,58 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+require_once dirname(__FILE__).'/OmiseRefund.php';
+
+class OmiseRefundList extends OmiseApiResource
+{
+    const ENDPOINT = 'refunds';
+
+    private $_chargeID;
+
+    /**
+     * @param array  $refunds
+     * @param string $chargeID
+     * @param string $publickey
+     * @param string $secretkey
+     */
+    public function __construct($refunds, $chargeID, $publickey = null, $secretkey = null)
+    {
+        parent::__construct($publickey, $secretkey);
+        $this->_chargeID = $chargeID;
+        $this->refresh($refunds);
+    }
+
+    /**
+     * @param  array $amount
+     *
+     * @return OmiseRefund
+     */
+    public function create($params)
+    {
+        $result = parent::execute($this->getUrl(), parent::REQUEST_POST, self::getResourceKey(), $params);
+
+        return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return OmiseRefund
+     */
+    public function retrieve($id)
+    {
+        $result = parent::execute($this->getUrl($id), parent::REQUEST_GET, self::getResourceKey());
+
+        return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private function getUrl($id = '')
+    {
+        return OMISE_API_URL.'charges/'.$this->_chargeID.'/'.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseRefundList.php
+++ b/lib/legacy/OmiseRefundList.php
@@ -3,6 +3,9 @@
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 require_once dirname(__FILE__).'/OmiseRefund.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseRefundList extends OmiseApiResource
 {
     const ENDPOINT = 'refunds';

--- a/lib/legacy/OmiseTest.php
+++ b/lib/legacy/OmiseTest.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseTest extends OmiseApiResource
+{
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::getInstance()
+     */
+    public static function resource()
+    {
+        return parent::getInstance(get_class());
+    }
+}

--- a/lib/legacy/OmiseTest.php
+++ b/lib/legacy/OmiseTest.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseTest extends OmiseApiResource
 {
     /**

--- a/lib/legacy/OmiseToken.php
+++ b/lib/legacy/OmiseToken.php
@@ -1,0 +1,57 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseVaultResource.php';
+
+class OmiseToken extends OmiseVaultResource
+{
+    const ENDPOINT = 'tokens';
+
+    /**
+     * Retrieves a token.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseToken
+     */
+    public static function retrieve($id, $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * Creates a new token. Please note that this method should be used only
+     * in development. In production please use Omise.js!
+     *
+     * @param  array  $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseToken
+     */
+    public static function create($params, $publickey = null, $secretkey = null)
+    {
+        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        parent::g_reload(self::getUrl($this['id']));
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_VAULT_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseToken.php
+++ b/lib/legacy/OmiseToken.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseVaultResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseToken extends OmiseVaultResource
 {
     const ENDPOINT = 'tokens';

--- a/lib/legacy/OmiseTransaction.php
+++ b/lib/legacy/OmiseTransaction.php
@@ -1,0 +1,46 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseTransaction extends OmiseApiResource
+{
+    const ENDPOINT = 'transactions';
+
+    /**
+     * Retrieves a transaction.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseTransaction
+     */
+    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        if ($this['object'] === 'transaction') {
+            parent::reload(self::getUrl($this['id']));
+        } else {
+            parent::g_reload(self::getUrl());
+        }
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseTransaction.php
+++ b/lib/legacy/OmiseTransaction.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseTransaction extends OmiseApiResource
 {
     const ENDPOINT = 'transactions';

--- a/lib/legacy/OmiseTransfer.php
+++ b/lib/legacy/OmiseTransfer.php
@@ -1,0 +1,98 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseTransfer extends OmiseApiResource
+{
+    const ENDPOINT = 'transfers';
+
+    /**
+     * Retrieves a transfer.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseTransfer
+     */
+    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * Creates a transfer.
+     *
+     * @param  mixed  $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseTransfer
+     */
+    public static function create($params, $publickey = null, $secretkey = null)
+    {
+        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        if ($this['object'] === 'transfers') {
+            parent::g_reload(self::getUrl($this['id']));
+        } else {
+            parent::g_reload(self::getUrl());
+        }
+    }
+
+    /**
+     * Updates the transfer amount.
+     */
+    public function save()
+    {
+        $this->update(array('amount' => $this['amount']));
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_update()
+     */
+    protected function update($params)
+    {
+        parent::g_update(self::getUrl($this['id']), $params);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_destroy()
+     */
+    public function destroy()
+    {
+        parent::g_destroy(self::getUrl($this['id']));
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::isDestroyed()
+     */
+    public function isDestroyed()
+    {
+        return parent::isDestroyed();
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/legacy/OmiseTransfer.php
+++ b/lib/legacy/OmiseTransfer.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseTransfer extends OmiseApiResource
 {
     const ENDPOINT = 'transfers';

--- a/lib/legacy/exception/OmiseExceptions.php
+++ b/lib/legacy/exception/OmiseExceptions.php
@@ -1,0 +1,94 @@
+<?php
+
+class OmiseException extends Exception
+{
+    private $_omiseError = null;
+
+    public function __construct($message = null, $omiseError = null)
+    {
+        parent::__construct($message);
+        $this->setOmiseError($omiseError);
+    }
+
+    /**
+     * Returns an instance of an exception class from the given error response.
+     *
+     * @param  array $array
+     *
+     * @return OmiseAuthenticationFailureException|OmiseNotFoundException|OmiseUsedTokenException|OmiseInvalidCardException|OmiseInvalidCardTokenException|OmiseMissingCardException|OmiseInvalidChargeException|OmiseFailedCaptureException|OmiseFailedFraudCheckException|OmiseUndefinedException
+     */
+    public static function getInstance($array)
+    {
+        switch ($array['code']) {
+            case 'authentication_failure':
+                return new OmiseAuthenticationFailureException($array['message'], $array);
+
+            case 'not_found':
+                return new OmiseNotFoundException($array['message'], $array);
+
+            case 'used_token':
+                return new OmiseUsedTokenException($array['message'], $array);
+
+            case 'invalid_card':
+                return new OmiseInvalidCardException($array['message'], $array);
+
+            case 'invalid_card_token':
+                return new OmiseInvalidCardTokenException($array['message'], $array);
+
+            case 'missing_card':
+                return new OmiseMissingCardException($array['message'], $array);
+
+            case 'invalid_charge':
+                return new OmiseInvalidChargeException($array['message'], $array);
+
+            case 'failed_capture':
+                return new OmiseFailedCaptureException($array['message'], $array);
+
+            case 'failed_fraud_check':
+                return new OmiseFailedFraudCheckException($array['message'], $array);
+
+            case 'invalid_recipient':
+                return new OmiseInvalidRecipientException($array['message'], $array);
+
+            case 'invalid_bank_account':
+                return new OmiseInvalidBankAccountException($array['message'], $array);
+
+            default:
+                return new OmiseUndefinedException($array['message'], $array);
+        }
+    }
+
+    /**
+     * Sets the error.
+     *
+     * @param OmiseError $omiseError
+     */
+    public function setOmiseError($omiseError)
+    {
+        $this->_omiseError = $omiseError;
+    }
+
+    /**
+     * Gets the OmiseError object. This method will return null if an error happens outside of the API. (For example, due to HTTP connectivity problem.)
+     * Please see https://docs.omise.co/api/errors/ for a list of possible errors.
+     *
+     * @return OmiseError
+     */
+    public function getOmiseError()
+    {
+        return $this->_omiseError;
+    }
+}
+
+class OmiseAuthenticationFailureException extends OmiseException { }
+class OmiseNotFoundException extends OmiseException { }
+class OmiseUsedTokenException extends OmiseException { }
+class OmiseInvalidCardException extends OmiseException { }
+class OmiseInvalidCardTokenException extends OmiseException { }
+class OmiseMissingCardException extends OmiseException { }
+class OmiseInvalidChargeException extends OmiseException { }
+class OmiseFailedCaptureException extends OmiseException { }
+class OmiseFailedFraudCheckException extends OmiseException { }
+class OmiseInvalidRecipientException extends OmiseException { }
+class OmiseInvalidBankAccountException extends OmiseException { }
+class OmiseUndefinedException extends OmiseException { }

--- a/lib/legacy/exception/OmiseExceptions.php
+++ b/lib/legacy/exception/OmiseExceptions.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseException extends Exception
 {
     private $_omiseError = null;
@@ -80,15 +83,62 @@ class OmiseException extends Exception
     }
 }
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseAuthenticationFailureException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseNotFoundException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseUsedTokenException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseInvalidCardException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseInvalidCardTokenException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseMissingCardException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseInvalidChargeException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseFailedCaptureException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseFailedFraudCheckException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseInvalidRecipientException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseInvalidBankAccountException extends OmiseException { }
+
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseUndefinedException extends OmiseException { }

--- a/lib/legacy/res/OmiseApiResource.php
+++ b/lib/legacy/res/OmiseApiResource.php
@@ -1,0 +1,316 @@
+<?php
+
+require_once dirname(__FILE__).'/obj/OmiseObject.php';
+require_once dirname(__FILE__).'/../exception/OmiseExceptions.php';
+
+define('OMISE_PHP_LIB_VERSION', '2.5.0');
+define('OMISE_API_URL', 'https://api.omise.co/');
+define('OMISE_VAULT_URL', 'https://vault.omise.co/');
+
+class OmiseApiResource extends OmiseObject
+{
+    // Request methods
+    const REQUEST_GET = 'GET';
+    const REQUEST_POST = 'POST';
+    const REQUEST_DELETE = 'DELETE';
+    const REQUEST_PATCH = 'PATCH';
+
+    // Timeout settings
+    private $OMISE_CONNECTTIMEOUT = 30;
+    private $OMISE_TIMEOUT = 60;
+
+    /**
+     * Returns an instance of the class given in $clazz or raise an error.
+     *
+     * @param  string $clazz
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @throws Exception
+     *
+     * @return OmiseResource
+     */
+    protected static function getInstance($clazz, $publickey = null, $secretkey = null)
+    {
+        if (class_exists($clazz)) {
+            return new $clazz($publickey, $secretkey);
+        }
+
+        throw new Exception('Undefined class.');
+    }
+
+    /**
+     * Retrieves the resource.
+     *
+     * @param  string $clazz
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @throws Exception|OmiseException
+     *
+     * @return OmiseAccount|OmiseBalance|OmiseCharge|OmiseCustomer|OmiseToken|OmiseTransaction|OmiseTransfer
+     */
+    protected static function g_retrieve($clazz, $url, $publickey = null, $secretkey = null)
+    {
+        $resource = call_user_func(array($clazz, 'getInstance'), $clazz, $publickey, $secretkey);
+        $result   = $resource->execute($url, self::REQUEST_GET, $resource->getResourceKey());
+        $resource->refresh($result);
+
+        return $resource;
+    }
+
+    /**
+     * Creates the resource with given parameters.in an associative array.
+     *
+     * @param  string $clazz
+     * @param  string $url
+     * @param  array  $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @throws Exception|OmiseException
+     *
+     * @return OmiseAccount|OmiseBalance|OmiseCharge|OmiseCustomer|OmiseToken|OmiseTransaction|OmiseTransfer
+     */
+    protected static function g_create($clazz, $url, $params, $publickey = null, $secretkey = null)
+    {
+        $resource = call_user_func(array($clazz, 'getInstance'), $clazz, $publickey, $secretkey);
+        $result   = $resource->execute($url, self::REQUEST_POST, $resource->getResourceKey(), $params);
+        $resource->refresh($result);
+
+        return $resource;
+    }
+
+    /**
+     * Updates the resource with the given parameters in an associative array.
+     *
+     * @param  string $url
+     * @param  array  $params
+     *
+     * @throws Exception|OmiseException
+     */
+    protected function g_update($url, $params)
+    {
+        $result = $this->execute($url, self::REQUEST_PATCH, $this->getResourceKey(), $params);
+        $this->refresh($result);
+    }
+
+    /**
+     * Destroys the resource.
+     *
+     * @param  string $url
+     *
+     * @throws Exception|OmiseException
+     *
+     * @return OmiseApiResource
+     */
+    protected function g_destroy($url)
+    {
+        $result = $this->execute($url, self::REQUEST_DELETE, $this->getResourceKey());
+        $this->refresh($result, true);
+    }
+
+    /**
+     * Reloads the resource with latest data.
+     *
+     * @param  string $url
+     *
+     * @throws Exception|OmiseException
+     */
+    protected function g_reload($url)
+    {
+        $result = $this->execute($url, self::REQUEST_GET, $this->getResourceKey());
+        $this->refresh($result);
+    }
+
+    /**
+     * Makes a request and returns a decoded JSON data as an associative array.
+     *
+     * @param  string $url
+     * @param  string $requestMethod
+     * @param  array  $params
+     *
+     * @throws OmiseException
+     *
+     * @return array
+     */
+    protected function execute($url, $requestMethod, $key, $params = null)
+    {
+        // If this class is execute by phpunit > get test mode.
+        if (preg_match('/phpunit/', $_SERVER['SCRIPT_NAME'])) {
+            $result = $this->_executeTest($url, $requestMethod, $key, $params);
+        } else {
+            $result = $this->_executeCurl($url, $requestMethod, $key, $params);
+        }
+
+        // Decode the JSON response as an associative array.
+        $array = json_decode($result, true);
+
+        // If response is invalid or not a JSON.
+        if (count($array) === 0 || ! isset($array['object'])) {
+            throw new Exception('Unknown error. (Bad Response)');
+        }
+
+        // If response is an error object.
+        if ($array['object'] === 'error') {
+            throw OmiseException::getInstance($array);
+        }
+
+        return $array;
+    }
+
+    /**
+     * @param  string $url
+     * @param  string $requestMethod
+     * @param  array  $params
+     *
+     * @throws OmiseException
+     *
+     * @return string
+     */
+    private function _executeCurl($url, $requestMethod, $key, $params = null)
+    {
+        $ch = curl_init($url);
+
+        curl_setopt_array($ch, $this->genOptions($requestMethod, $key.':', $params));
+
+        // Make a request or thrown an exception.
+        if (($result = curl_exec($ch)) === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+
+            throw new Exception($error);
+        }
+
+        // Close.
+        curl_close($ch);
+
+        return $result;
+    }
+
+    /**
+     * @param  string $url
+     * @param  string $requestMethod
+     * @param  array  $params
+     *
+     * @throws OmiseException
+     *
+     * @return string
+     */
+    private function _executeTest($url, $requestMethod, $key, $params = null)
+    {
+        // Remove Http, Https protocal from $url (string).
+        $request_url = preg_replace('#^(http|https)://#', '', $url);
+
+        // Remove slash if it had in last letter.
+        $request_url = rtrim($request_url, '/');
+
+        // Finally.
+        $request_url = dirname(__FILE__).'/../../../tests/fixtures/'.$request_url.'-'.strtolower($requestMethod).'.json';
+
+        // Make a request from Curl if json file was not exists.
+        if (! file_exists($request_url)) {
+            // Get a directory that's file should contain.
+            $request_dir = explode('/', $request_url);
+            unset($request_dir[count($request_dir) - 1]);
+            $request_dir = implode('/', $request_dir);
+
+            // Create directory if it not exists.
+            if (! file_exists($request_dir)) {
+                mkdir($request_dir, 0777, true);
+            }
+
+            $result = $this->_executeCurl($url, $requestMethod, $key, $params);
+
+            $f = fopen($request_url, 'w');
+            if ($f) {
+                fwrite($f, $result);
+
+                fclose($f);
+            }
+        } else { // Or get response from json file.
+            $result = file_get_contents($request_url);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Creates an option for php-curl from the given request method and parameters in an associative array.
+     *
+     * @param  string $requestMethod
+     * @param  array  $params
+     *
+     * @return array
+     */
+    private function genOptions($requestMethod, $userpwd, $params)
+    {
+        $user_agent        = "OmisePHP/".OMISE_PHP_LIB_VERSION;
+        $omise_api_version = defined('OMISE_API_VERSION') ? OMISE_API_VERSION : null;
+
+        $options = array(
+            // Set the HTTP version to 1.1.
+            CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,
+            // Set the request method.
+            CURLOPT_CUSTOMREQUEST  => $requestMethod,
+            // Make php-curl returns the data as string.
+            CURLOPT_RETURNTRANSFER => true,
+            // Do not include the header in the output.
+            CURLOPT_HEADER         => false,
+            // Track the header request string and set the referer on redirect.
+            CURLINFO_HEADER_OUT    => true,
+            CURLOPT_AUTOREFERER    => true,
+            // Make HTTP error code above 400 an error.
+            // CURLOPT_FAILONERROR => true,
+            // Time before the request is aborted.
+            CURLOPT_TIMEOUT        => $this->OMISE_TIMEOUT,
+            // Time before the request is aborted when attempting to connect.
+            CURLOPT_CONNECTTIMEOUT => $this->OMISE_CONNECTTIMEOUT,
+            // Authentication.
+            CURLOPT_USERPWD        => $userpwd,
+            // CA bundle.
+            CURLOPT_CAINFO         => dirname(__FILE__).'/../../../data/ca_certificates.pem'
+        );
+
+        // Config Omise API Version
+        if ($omise_api_version) {
+            $options += array(CURLOPT_HTTPHEADER => array("Omise-Version: ".$omise_api_version));
+
+            $user_agent .= ' OmiseAPI/'.$omise_api_version;
+        }
+
+        // Config UserAgent
+        if (defined('OMISE_USER_AGENT_SUFFIX')) {
+            $options += array(CURLOPT_USERAGENT => $user_agent." ".OMISE_USER_AGENT_SUFFIX);
+        } else {
+            $options += array(CURLOPT_USERAGENT => $user_agent);
+        }
+
+        // Also merge POST parameters with the option.
+        if (count($params) > 0) {
+            $options += array(CURLOPT_POSTFIELDS => http_build_query($params));
+        }
+
+        return $options;
+    }
+
+    /**
+     * Checks whether the resource has been destroyed.
+     *
+     * @return OmiseApiResource
+     */
+    protected function isDestroyed()
+    {
+        return $this['deleted'];
+    }
+
+    /**
+     * Returns the secret key.
+     *
+     * @return string
+     */
+    protected function getResourceKey()
+    {
+        return $this->_secretkey;
+    }
+}

--- a/lib/legacy/res/OmiseApiResource.php
+++ b/lib/legacy/res/OmiseApiResource.php
@@ -7,6 +7,9 @@ define('OMISE_PHP_LIB_VERSION', '2.5.0');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseApiResource extends OmiseObject
 {
     // Request methods

--- a/lib/legacy/res/OmiseVaultResource.php
+++ b/lib/legacy/res/OmiseVaultResource.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once dirname(__FILE__).'/OmiseApiResource.php';
+
+class OmiseVaultResource extends OmiseApiResource
+{
+    /**
+     * Returns the public key.
+     *
+     * @return string
+     */
+    protected function getResourceKey()
+    {
+        return $this->_publickey;
+    }
+}

--- a/lib/legacy/res/OmiseVaultResource.php
+++ b/lib/legacy/res/OmiseVaultResource.php
@@ -2,6 +2,9 @@
 
 require_once dirname(__FILE__).'/OmiseApiResource.php';
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseVaultResource extends OmiseApiResource
 {
     /**

--- a/lib/legacy/res/obj/OmiseObject.php
+++ b/lib/legacy/res/obj/OmiseObject.php
@@ -1,0 +1,105 @@
+<?php
+
+class OmiseObject implements ArrayAccess, Iterator, Countable
+{
+    // Store the attributes of the object.
+    protected $_values = array();
+
+    // Omise secret key.
+    protected $_secretkey;
+
+    // Omise public key.
+    protected $_publickey;
+
+    /**
+     * Setup the Omise object. If no secret and public are passed the one defined
+     * in config.php will be used.
+     *
+     * @param string $publickey
+     * @param string $secretkey
+     */
+    protected function __construct($publickey = null, $secretkey = null)
+    {
+        if ($publickey !== null) {
+            $this->_publickey = $publickey;
+        } else {
+            $this->_publickey = OMISE_PUBLIC_KEY;
+        }
+
+        if ($secretkey !== null) {
+            $this->_secretkey = $secretkey;
+        } else {
+            $this->_secretkey = OMISE_SECRET_KEY;
+        }
+
+        $this->_values = array();
+    }
+
+    /**
+     * Reload the object.
+     *
+     * @param array   $values
+     * @param boolean $clear
+     */
+    public function refresh($values, $clear = false)
+    {
+        if ($clear) {
+            $this->_values = array();
+        }
+
+        $this->_values = array_merge($this->_values, $values);
+    }
+
+    // Override methods of ArrayAccess
+    public function offsetSet($key, $value)
+    {
+        $this->_values[$key] = $value;
+    }
+
+    public function offsetExists($key)
+    {
+        return isset($this->_values[$key]);
+    }
+
+    public function offsetUnset($key)
+    {
+        unset($this->_values[$key]);
+    }
+
+    public function offsetGet($key)
+    {
+        return isset($this->_values[$key]) ? $this->_values[$key] : null;
+    }
+
+    // Override methods of Iterator
+    public function rewind()
+    {
+        reset($this->_values);
+    }
+
+    public function current()
+    {
+        return current($this->_values);
+    }
+
+    public function key()
+    {
+        return key($this->_values);
+    }
+
+    public function next()
+    {
+        return next($this->_values);
+    }
+
+    public function valid()
+    {
+        return ($this->current() !== false);
+    }
+
+    // Override methods of Countable
+    public function count()
+    {
+        return count($this->_values);
+    }
+}

--- a/lib/legacy/res/obj/OmiseObject.php
+++ b/lib/legacy/res/obj/OmiseObject.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @deprecated 3.0.0 not recommended, please implement with namespace approach.
+ */
 class OmiseObject implements ArrayAccess, Iterator, Countable
 {
     // Store the attributes of the object.

--- a/lib/omise/OmiseAccount.php
+++ b/lib/omise/OmiseAccount.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+use Omise\Res\OmiseApiResource;
 
 class OmiseAccount extends OmiseApiResource
 {

--- a/lib/omise/OmiseBalance.php
+++ b/lib/omise/OmiseBalance.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+use Omise\Res\OmiseApiResource;
 
 class OmiseBalance extends OmiseApiResource
 {

--- a/lib/omise/OmiseCard.php
+++ b/lib/omise/OmiseCard.php
@@ -1,7 +1,8 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseCustomer.php';
+use Omise\Res\OmiseApiResource;
+use Omise\OmiseCustomer;
 
 class OmiseCard extends OmiseApiResource
 {

--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -1,7 +1,8 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseCard.php';
+use Omise\Res\OmiseApiResource;
+use Omise\OmiseCard;
 
 class OmiseCardList extends OmiseApiResource
 {

--- a/lib/omise/OmiseCharge.php
+++ b/lib/omise/OmiseCharge.php
@@ -1,7 +1,8 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseRefundList.php';
+use Omise\Res\OmiseApiResource;
+use Omise\OmiseRefundList;
 
 class OmiseCharge extends OmiseApiResource
 {

--- a/lib/omise/OmiseCustomer.php
+++ b/lib/omise/OmiseCustomer.php
@@ -1,7 +1,8 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseCardList.php';
+use Omise\Res\OmiseApiResource;
+use Omise\OmiseCardList;
 
 class OmiseCustomer extends OmiseApiResource
 {

--- a/lib/omise/OmiseDispute.php
+++ b/lib/omise/OmiseDispute.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+use Omise\Res\OmiseApiResource;
 
 class OmiseDispute extends OmiseApiResource
 {

--- a/lib/omise/OmiseEvent.php
+++ b/lib/omise/OmiseEvent.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+use Omise\Res\OmiseApiResource;
 
 class OmiseEvent extends OmiseApiResource
 {

--- a/lib/omise/OmiseRecipient.php
+++ b/lib/omise/OmiseRecipient.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+use Omise\Res\OmiseApiResource;
 
 class OmiseRecipient extends OmiseApiResource
 {

--- a/lib/omise/OmiseRefund.php
+++ b/lib/omise/OmiseRefund.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+use Omise\Res\OmiseApiResource;
 
 class OmiseRefund extends OmiseApiResource
 {

--- a/lib/omise/OmiseRefundList.php
+++ b/lib/omise/OmiseRefundList.php
@@ -1,7 +1,8 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseRefund.php';
+use Omise\Res\OmiseApiResource;
+use Omise\OmiseRefund;
 
 class OmiseRefundList extends OmiseApiResource
 {

--- a/lib/omise/OmiseTest.php
+++ b/lib/omise/OmiseTest.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+use Omise\Res\OmiseApiResource;
 
 class OmiseTest extends OmiseApiResource
 {

--- a/lib/omise/OmiseToken.php
+++ b/lib/omise/OmiseToken.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseVaultResource.php';
+use Omise\Res\OmiseVaultResource;
 
 class OmiseToken extends OmiseVaultResource
 {

--- a/lib/omise/OmiseTransaction.php
+++ b/lib/omise/OmiseTransaction.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+use Omise\Res\OmiseApiResource;
 
 class OmiseTransaction extends OmiseApiResource
 {

--- a/lib/omise/OmiseTransfer.php
+++ b/lib/omise/OmiseTransfer.php
@@ -1,6 +1,7 @@
 <?php
+namespace Omise;
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+use Omise\Res\OmiseApiResource;
 
 class OmiseTransfer extends OmiseApiResource
 {

--- a/lib/omise/exception/OmiseException.php
+++ b/lib/omise/exception/OmiseException.php
@@ -1,4 +1,7 @@
 <?php
+namespace Omise\Exception;
+
+use Exception;
 
 class OmiseException extends Exception
 {

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -1,7 +1,8 @@
 <?php
+namespace Omise\Res;
 
-require_once dirname(__FILE__).'/obj/OmiseObject.php';
-require_once dirname(__FILE__).'/../exception/OmiseExceptions.php';
+use Omise\Res\Obj\OmiseObject;
+use Omise\Exception\OmiseException;
 
 define('OMISE_PHP_LIB_VERSION', '2.5.0');
 define('OMISE_API_URL', 'https://api.omise.co/');

--- a/lib/omise/res/OmiseVaultResource.php
+++ b/lib/omise/res/OmiseVaultResource.php
@@ -1,4 +1,5 @@
 <?php
+namespace Omise\Res;
 
 require_once dirname(__FILE__).'/OmiseApiResource.php';
 

--- a/lib/omise/res/obj/OmiseObject.php
+++ b/lib/omise/res/obj/OmiseObject.php
@@ -1,4 +1,9 @@
 <?php
+namespace Omise\Res\Obj;
+
+use ArrayAccess;
+use Countable;
+use Iterator;
 
 class OmiseObject implements ArrayAccess, Iterator, Countable
 {

--- a/tests/omise/res/obj/OmiseObjectTest.php
+++ b/tests/omise/res/obj/OmiseObjectTest.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once dirname(__FILE__).'/../../TestConfig.php';
-require_once dirname(__FILE__).'/../../../../lib/omise/OmiseTest.php';
+require_once dirname(__FILE__).'/../../../../lib/legacy/OmiseTest.php';
 
 class OmiseObjectTest extends TestConfig {
   static $obj;


### PR DESCRIPTION
> **Note**, need PR #46 to be merged first.

### 1. Objective reason

Continue with PR #46. This PR aimed to add `namespace` back to all of Omise classes.

### 2. Description of change

- Add `PSR-4` spec to composer.json
- New namespaces were introduced to all of Omise classes, the list of namespaces are as follows:

File                                   | Class              | Namespace 
-------------------------------------- | ------------------ | ------------------------
lib/omise/OmiseAccount.php             | OmiseAccount       | Omise\OmiseAccount
lib/omise/OmiseBalance.php             | OmiseBalance       | Omise\OmiseBalance
lib/omise/OmiseCard.php                | OmiseCard          | Omise\OmiseCard
lib/omise/OmiseCardList.php            | OmiseCardList      | Omise\OmiseCardList
lib/omise/OmiseCharge.php              | OmiseCharge        | Omise\OmiseCharge
lib/omise/OmiseCustomer.php            | OmiseCustomer      | Omise\OmiseCustomer
lib/omise/OmiseDispute.php             | OmiseDispute       | Omise\OmiseDispute
lib/omise/OmiseEvent.php               | OmiseEvent         | Omise\OmiseEvent
lib/omise/OmiseRecipient.php           | OmiseRecipient     | Omise\OmiseRecipient
lib/omise/OmiseRefund.php              | OmiseRefund        | Omise\OmiseRefund
lib/omise/OmiseRefundList.php          | OmiseRefundList    | Omise\OmiseRefundList
lib/omise/OmiseTest.php                | OmiseTest          | Omise\OmiseTest
lib/omise/OmiseToken.php               | OmiseToken         | Omise\OmiseToken
lib/omise/OmiseTransaction.php         | OmiseTransaction   | Omise\OmiseTransaction
lib/omise/OmiseTransfer.php            | OmiseTransfer      | Omise\OmiseTransfer
lib/omise/res/OmiseApiResource.php     | OmiseApiResource   | Omise\Res\OmiseApiResource
lib/omise/res/OmiseVaultResource.php   | OmiseVaultResource | Omise\Res\OmiseVaultResource
lib/omise/res/obj/OmiseObject.php      | OmiseObject        | Omise\Res\Obj\OmiseObject
lib/omise/exception/OmiseException.php | OmiseException     | Omise\Exception\OmiseException

**Note**: `lib/omise/exception/OmiseExceptions.php` was changed to `lib/omise/exception/OmiseException.php` to make it corresponding to its class.

### 3. Users affected by the change

No

### 4. Impact of the change

No

### 5. Priority of change

Normal

### 6. Alternate solution

No