### PR TITLE
Fix can't retrieve card from Card API

### DIFF
--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -9,6 +9,9 @@ class OmiseCardList extends OmiseApiResource
 
     private $_customerID;
 
+    protected $publickey;
+    protected $secretkey;
+
     /**
      * @param array  $cards
      * @param string $customerID
@@ -18,11 +21,14 @@ class OmiseCardList extends OmiseApiResource
     public function __construct($cards, $customerID, $options = array(), $publickey = null, $secretkey = null)
     {
         if (! is_array($options) && func_num_args() == 4) {
-            $omise_publickey = func_get_arg(2);
-            $omise_secretkey = func_get_arg(3);
+            $this->publickey = func_get_arg(2);
+            $this->secretkey = func_get_arg(3);
+        } else {
+            $this->publickey = func_get_arg(3);
+            $this->secretkey = func_get_arg(4);
         }
 
-        parent::__construct($omise_publickey, $omise_secretkey);
+        parent::__construct($this->publickey, $this->secretkey);
         $this->_customerID = $customerID;
 
         if (is_array($options)) {

--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -9,8 +9,8 @@ class OmiseCardList extends OmiseApiResource
 
     private $_customerID;
 
-    protected $publickey;
-    protected $secretkey;
+    private $publickey;
+    private $secretkey;
 
     /**
      * @param array  $cards

--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -8,7 +8,7 @@ class OmiseCardList extends OmiseApiResource
     const ENDPOINT = 'cards';
 
     private $_customerID;
-  
+
     /**
      * @param array  $cards
      * @param string $customerID
@@ -18,11 +18,11 @@ class OmiseCardList extends OmiseApiResource
     public function __construct($cards, $customerID, $options = array(), $publickey = null, $secretkey = null)
     {
         if (! is_array($options) && func_num_args() == 4) {
-            $publickey = func_get_arg(2);
-            $secretkey = func_get_arg(3);
+            $omise_publickey = func_get_arg(2);
+            $omise_secretkey = func_get_arg(3);
         }
 
-        parent::__construct($publickey, $secretkey);
+        parent::__construct($omise_publickey, $omise_secretkey);
         $this->_customerID = $customerID;
 
         if (is_array($options)) {
@@ -31,7 +31,7 @@ class OmiseCardList extends OmiseApiResource
             $this->refresh($cards);
         }
     }
-  
+
     /**
      * retrieve a card
      *
@@ -45,7 +45,6 @@ class OmiseCardList extends OmiseApiResource
 
         return new OmiseCard($result, $this->_customerID, $this->_publickey, $this->_secretkey);
     }
-  
 
     /**
      * @param  string $id


### PR DESCRIPTION
#### 1. Objective reason

We can't retrieve card from Card API. I thought the problem cause is class `OmiseCardList` variable name has been overlapped so the data always return `publickey`

```
$customer = OmiseCustomer::retrieve('cust_test_xxxxxxxxxxxxxxxxxxxxxx');

$card = $customer->getCards()->retrieve(CARD_ID);
```

I think that code below is a problem
```
$publickey = func_get_arg(2);
$secretkey = func_get_arg(3);
```

`$secretkey` always be a value same as `$publickey`, the problem is may come from `func_get_arg` method.

PS. according to http://php.net/manual/en/function.func-get-arg.php, I think the problem will appear only when using PHP version over 7.

#### 2. Description of change

- change variable name to not overlap.

PS. I tested with PHP version `5.6` and `7` on my MAMP.

#### 3. Users affected by the change

None.

#### 4. Impact of the change

None.

#### 5. Priority of change

Immediately

#### 6. Alternate solution (if any)

None.