### PR TITLE
Remove unreasonable conditional block from OmiseCustomer lib

### DIFF
--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -17,15 +17,10 @@ class OmiseCardList extends OmiseApiResource
      */
     public function __construct($cards, $customerID, $options = array(), $publickey = null, $secretkey = null)
     {
-        if (! is_array($options) && func_num_args() == 4) {
-            $publickey = func_get_arg(2);
-            $secretkey = func_get_arg(3);
-        }
-
         parent::__construct($publickey, $secretkey);
         $this->_customerID = $customerID;
 
-        if (is_array($options)) {
+        if (is_array($options) && ! empty($options)) {
             parent::g_reload($this->getUrl('?'.http_build_query($options)));
         } else {
             $this->refresh($cards);

--- a/lib/omise/OmiseCustomer.php
+++ b/lib/omise/OmiseCustomer.php
@@ -88,10 +88,8 @@ class OmiseCustomer extends OmiseApiResource
      */
     public function cards($options = array())
     {
-        if ($this['object'] === 'customer' && ! empty($options)) {
+        if ($this['object'] === 'customer') {
             return new OmiseCardList($this['cards'], $this['id'], $options, $this->_publickey, $this->_secretkey);
-        } else if ($this['object'] === 'customer') {
-            return new OmiseCardList($this['cards'], $this['id'], $this->_publickey, $this->_secretkey);
         }
     }
   


### PR DESCRIPTION
#### 1. Objective

To fix that the use case below would break and raise `authentication failed` error
```php
define('OMISE_PUBLIC_KEY', 'my_public_key');
define('OMISE_SECRET_KEY', 'my_secret_key');

$customer = OmiseCustomer::retrieve('customer_id');
$card     = $customer->cards()->retrieve('card_id');

var_dump($card);
```

**Result:**
![screen shot 2559-12-23 at 2 08 47 pm](https://cloud.githubusercontent.com/assets/2154669/21448835/84367528-c919-11e6-95c9-aab9d1d3adbf.png)

If consider at code
https://github.com/omise/omise-php/blob/master/lib/omise/OmiseCardList.php#L18
```php
// OmiseCardList.php

public function __construct($cards, $customerID, $options = array(), $publickey = null, $secretkey = null)
{
    if (! is_array($options) && func_num_args() == 4) {
        $publickey = func_get_arg(2);
        $secretkey = func_get_arg(3);
    }

    parent::__construct($publickey, $secretkey);
    $this->_customerID = $customerID;

    if (is_array($options)) {
        parent::g_reload($this->getUrl('?'.http_build_query($options)));
    } else {
        $this->refresh($cards);
    }
}
```

**By the use case above**, it would raise into the conditional block below
```php
// OmiseCardList.php

public function __construct($cards, $customerID, $options = array(), $publickey = null, $secretkey = null)
{
    // If we debug all of args here, we would get:
    echo func_get_arg(0); // arg 0 = $cards, result is Array
    echo func_get_arg(1); // arg 1 = $customerID, result is "customer_id"
    echo func_get_arg(2); // arg 2 = $options, result is "my_public_key"
    echo func_get_arg(3); // arg 3 = $publickey, result is "my_secret_key"

    // Code would raise into this conditional block.
    if (! is_array($options) && func_num_args() == 4) {
        // Here, we retrieve "$options" and assigned the value to "$publickey"
        $publickey = func_get_arg(2);

        // Here, we retrieve "$publickey", we suppose to get "my_secret_key", 
        // but instead, we get value that came from "$options" 
        // because we re-assigned "func_get_arg(2)" to "$publickey", which is "$public" = the 3rd arg.
        $secretkey = func_get_arg(3);
    }

    // Try debug again
    echo func_get_arg(0); // arg 0 = $cards, result is Array
    echo func_get_arg(1); // arg 1 = $customerID, result is "customer_id"
    echo func_get_arg(2); // arg 2 = $options, result is "my_public_key"
    echo func_get_arg(3); // arg 3 = $publickey, result is "my_public_key"

    ...
}
```

#### 2. Description of change

Instead of fix that issue directly, I've found that we don't need to have some condition in `OmiseCustomer::cards()` method, which is, I removed `if else` block in `OmiseCustomer::cards()` that made `OmiseCardList::__construct()` doesn't need to have a condition block to check `if func_num_args() === 4`

#### 3. Quality assurance

**🔧 Environments:**

tested on PHP version `5.6.28`, `7.0.14`.

**✏️ Details:**

Run the use case above again.
```php
define('OMISE_PUBLIC_KEY', 'my_public_key');
define('OMISE_SECRET_KEY', 'my_secret_key');

$customer = OmiseCustomer::retrieve('customer_id');
$card     = $customer->cards()->retrieve('card_id');

var_dump($card);
```

**Result::**
![screen shot 2559-12-23 at 3 03 52 pm](https://cloud.githubusercontent.com/assets/2154669/21449565/225a9a70-c921-11e6-8bb6-397b8b14aa96.png)

Note.
I also tested with the code below to see if we can overwrite values of $pkey & $skey.
```php
define('OMISE_PUBLIC_KEY', ''); // Defined nothing.
define('OMISE_SECRET_KEY', ''); // Defined nothing.

$customer = OmiseCustomer::retrieve('customer_id', 'my_public_key', 'my_secret_key');
$card     = $customer->cards()->retrieve('card_id');

var_dump($card);
```

#### 4. Impact of the change

No.

#### 5. Priority of change

High (Bug)

#### 6. Additional Notes

No.
