### PR TITLE
Include PHP Version to the USER-AGENT header when make a request to O…

### DIFF
--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -250,7 +250,7 @@ class OmiseApiResource extends OmiseObject
      */
     private function genOptions($requestMethod, $userpwd, $params)
     {
-        $user_agent        = "OmisePHP/" . OMISE_PHP_LIB_VERSION . " PHP/" . phpversion();
+        $user_agent        = "OmisePHP/".OMISE_PHP_LIB_VERSION." PHP/".phpversion();
         $omise_api_version = defined('OMISE_API_VERSION') ? OMISE_API_VERSION : null;
 
         $options = array(

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -250,7 +250,7 @@ class OmiseApiResource extends OmiseObject
      */
     private function genOptions($requestMethod, $userpwd, $params)
     {
-        $user_agent        = "OmisePHP/".OMISE_PHP_LIB_VERSION;
+        $user_agent        = "OmisePHP/" . OMISE_PHP_LIB_VERSION . " PHP/" . phpversion();
         $omise_api_version = defined('OMISE_API_VERSION') ? OMISE_API_VERSION : null;
 
         $options = array(


### PR DESCRIPTION
#### 1. Objective

Enhance Omise-PHP library, that Omise can provide an appropriate and better support on each of PHP environment by knowing PHP version from clients.

**Related information**:
Related issue(s): 🙅

#### 2. Description of change

- Include PHP version to the `USER-AGENT` header when make a request to the Omise APIs.

#### 3. Quality assurance

**🔧 Environments:**

- **PHP version**: 7.0.16.

**✏️ Details:**

1. Try make any request to Omise API, at the requested log in Omise dashboard, you will see `PHP/x.y.z` appeared at the `USER AGENT` section.

    ![025](https://cloud.githubusercontent.com/assets/2154669/24138500/022a08b6-0e4b-11e7-990e-aca6bf976862.png)


#### 4. Impact of the change

No impact.

#### 5. Priority of change

Normal.

#### 6. Additional Notes

- I think this comment is nice to know, http://php.net/manual/en/function.phpversion.php#119607
    > Note that the version string returned by phpversion() may include more information than expected: "5.5.9-1ubuntu4.17", for example.