### PR TITLE
Correct the Docblock at OmiseApiResource::isDestroy() method.

### DIFF
--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -302,7 +302,7 @@ class OmiseApiResource extends OmiseObject
     /**
      * Checks whether the resource has been destroyed.
      *
-     * @return OmiseApiResource
+     * @return bool|null
      */
     protected function isDestroyed()
     {


### PR DESCRIPTION
#### 1. Objective

To correct a return tag (`@return`) in the OmiseApiResource::isDestroy() method's Docblock.

**Related information**:
Related issue(s): #43 

#### 2. Description of change

- Change `@return OmiseApiResource` to `@return bool|null`

#### 3. Quality assurance

> This change wasn't effect to any part of an implementation code.

By the way, the following code will shows `bool(true)`. 
_Note, you must have at least 1 customer object to test the following code._

```php
$customers = OmiseCustomer::retrieve();
$customer  = OmiseCustomer::retrieve($customers['data'][0]['id']);
$customer->destroy();

var_dump($customer->isDestroyed()); exit;
```

#### 4. Impact of the change

No impact.

#### 5. Priority of change

Normal.

#### 6. Additional Notes

No.
