### PR TITLE
Provide exception classes for 'invalid_link', 'failed_refund' and 'bad_request' error code

### DIFF
--- a/lib/omise/exception/OmiseExceptions.php
+++ b/lib/omise/exception/OmiseExceptions.php
@@ -23,6 +23,9 @@ class OmiseException extends Exception
             case 'authentication_failure':
                 return new OmiseAuthenticationFailureException($array['message'], $array);
 
+            case 'bad_request':
+                return new OmiseBadRequestException($array['message'], $array);
+
             case 'not_found':
                 return new OmiseNotFoundException($array['message'], $array);
 
@@ -46,6 +49,12 @@ class OmiseException extends Exception
 
             case 'failed_fraud_check':
                 return new OmiseFailedFraudCheckException($array['message'], $array);
+
+            case 'failed_refund':
+                return new OmiseFailedRefundException($array['message'], $array);
+
+            case 'invalid_link':
+                return new OmiseInvalidLinkException($array['message'], $array);
 
             case 'invalid_recipient':
                 return new OmiseInvalidRecipientException($array['message'], $array);
@@ -81,6 +90,7 @@ class OmiseException extends Exception
 }
 
 class OmiseAuthenticationFailureException extends OmiseException { }
+class OmiseBadRequestException extends OmiseException { }
 class OmiseNotFoundException extends OmiseException { }
 class OmiseUsedTokenException extends OmiseException { }
 class OmiseInvalidCardException extends OmiseException { }
@@ -89,6 +99,8 @@ class OmiseMissingCardException extends OmiseException { }
 class OmiseInvalidChargeException extends OmiseException { }
 class OmiseFailedCaptureException extends OmiseException { }
 class OmiseFailedFraudCheckException extends OmiseException { }
+class OmiseFailedRefundException extends OmiseException { }
+class OmiseInvalidLinkException extends OmiseException { }
 class OmiseInvalidRecipientException extends OmiseException { }
 class OmiseInvalidBankAccountException extends OmiseException { }
 class OmiseUndefinedException extends OmiseException { }

--- a/tests/omise/exception/OmiseExceptionTest.php
+++ b/tests/omise/exception/OmiseExceptionTest.php
@@ -34,6 +34,19 @@ class OmiseExceptionTest extends PHPUnit_Framework_TestCase {
   }
 
   /**
+   * @expectedException         OmiseBadRequestException
+   * @expectedExceptionMessage  offsite is not valid
+   */
+  public function testOmiseBadRequestException() {
+    $mock = array('object'    => 'error',
+                  'location'  => 'https://www.omise.co/api-errors#bad-request',
+                  'code'      => 'bad_request',
+                  'message'   => 'offsite is not valid');
+
+    throw OmiseException::getInstance($mock);
+  }
+
+  /**
    * @expectedException         OmiseNotFoundException
    * @expectedExceptionMessage  customer cust_test_000000000000 was not found
    */
@@ -86,6 +99,19 @@ class OmiseExceptionTest extends PHPUnit_Framework_TestCase {
   }
 
   /**
+   * @expectedException         OmiseInvalidLinkException
+   * @expectedExceptionMessage  amount must be less than or equal to 1000000.0
+   */
+  public function testInvalidLinkException () {
+    $mock = array('object'    => 'error',
+                  'location'  => 'https://www.omise.co/api-errors#invalid-link',
+                  'code'      => 'invalid_link',
+                  'message'   => 'amount must be less than or equal to 1000000.0');
+
+    throw OmiseException::getInstance($mock);
+  }
+
+  /**
    * @expectedException         OmiseMissingCardException
    * @expectedExceptionMessage  request contains no card parameters
    */
@@ -120,6 +146,19 @@ class OmiseExceptionTest extends PHPUnit_Framework_TestCase {
                   'location'  => 'https://docs.omise.co/api/errors#failed-capture',
                   'code'      => 'failed_capture',
                   'message'   => 'Charge is not authorized');
+
+    throw OmiseException::getInstance($mock);
+  }
+
+  /**
+   * @expectedException         OmiseFailedRefundException
+   * @expectedExceptionMessage  amount is not a number
+   */
+  public function testFailedRefundException () {
+    $mock = array('object'    => 'error',
+                  'location'  => 'https://www.omise.co/api-errors#failed-refund',
+                  'code'      => 'failed_refund',
+                  'message'   => 'amount is not a number');
 
     throw OmiseException::getInstance($mock);
   }


### PR DESCRIPTION
#### 1. Objective

To handle new Omise API error code (`invalid_link`, `failed_refund` and `bad_request`).

#### 2. Description of change

2.1. Add new exception classes to handle those error code.

#### 3. Quality assurance

Consider the code below:

```php
try {
    $link = OmiseLink::create([
        'amount' => 'xxx'
    ]);
} catch (Exception $e) {
    if ($e instanceof OmiseInvalidLinkException) {
        echo 'Threw into OmiseInvalidLinkException';
    } else {
        echo $e->getMessage();
    }
}

// Output: Threw into OmiseInvalidLinkException
```

From the example code above, `OmiseLink::create(['amount'=>'xxx']);` will raise an error 

```json
{
  "object": "error",
  "location": "https://www.omise.co/api-errors#invalid-link",
  "code": "invalid_link",
  "message": "amount must be less than or equal to 1000000.0, amount must be greater than or equal to 20.0, and amount can't be blank"
}
```

And it will be thrown into `OmiseInvalidLinkException` class as we defined.

Check for the rest of new error exception classes at https://github.com/omise/omise-php/pull/61/files#diff-c81887b90d2c5173a846673383875338

#### 4. Impact of the change

No.

#### 5. Additional notes

No.
