### PR TITLE
Support Schedule APIs

### DIFF
--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -12,6 +12,7 @@ require_once dirname(__FILE__).'/omise/OmiseCustomer.php';
 require_once dirname(__FILE__).'/omise/OmiseRefund.php';
 require_once dirname(__FILE__).'/omise/OmiseRefundList.php';
 require_once dirname(__FILE__).'/omise/OmiseSearch.php';
+require_once dirname(__FILE__).'/omise/OmiseSchedule.php';
 require_once dirname(__FILE__).'/omise/OmiseTransfer.php';
 require_once dirname(__FILE__).'/omise/OmiseTransaction.php';
 require_once dirname(__FILE__).'/omise/OmiseRecipient.php';

--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -9,6 +9,7 @@ require_once dirname(__FILE__).'/omise/OmiseEvent.php';
 require_once dirname(__FILE__).'/omise/OmiseToken.php';
 require_once dirname(__FILE__).'/omise/OmiseCharge.php';
 require_once dirname(__FILE__).'/omise/OmiseCustomer.php';
+require_once dirname(__FILE__).'/omise/OmiseOccurrence.php';
 require_once dirname(__FILE__).'/omise/OmiseRefund.php';
 require_once dirname(__FILE__).'/omise/OmiseRefundList.php';
 require_once dirname(__FILE__).'/omise/OmiseSearch.php';

--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -14,6 +14,7 @@ require_once dirname(__FILE__).'/omise/OmiseRefund.php';
 require_once dirname(__FILE__).'/omise/OmiseRefundList.php';
 require_once dirname(__FILE__).'/omise/OmiseSearch.php';
 require_once dirname(__FILE__).'/omise/OmiseSchedule.php';
+require_once dirname(__FILE__).'/omise/OmiseScheduler.php';
 require_once dirname(__FILE__).'/omise/OmiseTransfer.php';
 require_once dirname(__FILE__).'/omise/OmiseTransaction.php';
 require_once dirname(__FILE__).'/omise/OmiseRecipient.php';

--- a/lib/omise/OmiseCharge.php
+++ b/lib/omise/OmiseCharge.php
@@ -51,6 +51,20 @@ class OmiseCharge extends OmiseApiResource
     }
 
     /**
+     * Schedule a charge.
+     *
+     * @param  string $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseScheduler
+     */
+    public static function schedule($params, $publickey = null, $secretkey = null)
+    {
+        return new OmiseScheduler('charge', $params, $publickey, $secretkey);
+    }
+
+    /**
      * Creates a new charge.
      *
      * @param  array  $params

--- a/lib/omise/OmiseCharge.php
+++ b/lib/omise/OmiseCharge.php
@@ -2,6 +2,7 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 require_once dirname(__FILE__).'/OmiseRefundList.php';
+require_once dirname(__FILE__).'/OmiseScheduleList.php';
 
 class OmiseCharge extends OmiseApiResource
 {
@@ -109,6 +110,24 @@ class OmiseCharge extends OmiseApiResource
         $result = parent::execute(self::getUrl($this['id']).'/refunds', parent::REQUEST_GET, parent::getResourceKey());
 
         return new OmiseRefundList($result, $this['id'], $this->_publickey, $this->_secretkey);
+    }
+
+    /**
+     * Gets a list of charge schedules.
+     *
+     * @param  array|string $options
+     * @param  string       $publickey
+     * @param  string       $secretkey
+     *
+     * @return OmiseScheduleList
+     */
+    public static function schedules($options = array(), $publickey = null, $secretkey = null)
+    {
+        if (is_array($options)) {
+            $options = '?' . http_build_query($options);
+        }
+
+        return parent::g_retrieve('OmiseScheduleList', self::getUrl('schedules' . $options), $publickey, $secretkey);
     }
 
     /**

--- a/lib/omise/OmiseCustomer.php
+++ b/lib/omise/OmiseCustomer.php
@@ -2,6 +2,7 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 require_once dirname(__FILE__).'/OmiseCardList.php';
+require_once dirname(__FILE__).'/OmiseScheduleList.php';
 
 class OmiseCustomer extends OmiseApiResource
 {
@@ -117,6 +118,24 @@ class OmiseCustomer extends OmiseApiResource
     public function getCards($options = array())
     {
         return $this->cards($options);
+    }
+
+    /**
+     * Gets a list of charge schedules that belongs to a given customer.
+     *
+     * @param  array|string $options
+     *
+     * @return OmiseScheduleList
+     */
+    public function schedules($options = array())
+    {
+        if ($this['object'] === 'customer') {
+            if (is_array($options)) {
+                $options = '?' . http_build_query($options);
+            }
+
+            return parent::g_retrieve('OmiseScheduleList', self::getUrl($this['id'] . '/schedules' . $options), $this->_publickey, $this->_secretkey);
+        }
     }
 
     /**

--- a/lib/omise/OmiseOccurrence.php
+++ b/lib/omise/OmiseOccurrence.php
@@ -1,0 +1,37 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseOccurrence extends OmiseApiResource
+{
+    const ENDPOINT = 'occurrences';
+
+    /**
+     * Retrieves an occurence object.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseOccurrence
+     */
+    public static function retrieve($id, $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    public function reload()
+    {
+        parent::g_reload(self::getUrl($this['id']));
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT . '/' . $id;
+    }
+}

--- a/lib/omise/OmiseOccurrenceList.php
+++ b/lib/omise/OmiseOccurrenceList.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseOccurrenceList extends OmiseApiResource
+{
+    /**
+     * @param  string $id
+     *
+     * @return OmiseOccurrence
+     */
+    public function retrieve($id)
+    {
+        return OmiseOccurrence::retrieve($id, $this->_publickey, $this->_secretkey);
+    }
+}

--- a/lib/omise/OmiseRecipient.php
+++ b/lib/omise/OmiseRecipient.php
@@ -93,6 +93,24 @@ class OmiseRecipient extends OmiseApiResource
     }
 
     /**
+     * Gets a list of transfer schedules that belongs to a given recipient.
+     *
+     * @param  array|string $options
+     *
+     * @return OmiseScheduleList
+     */
+    public function schedules($options = array())
+    {
+        if ($this['object'] === 'recipient') {
+            if (is_array($options)) {
+                $options = '?' . http_build_query($options);
+            }
+
+            return parent::g_retrieve('OmiseScheduleList', self::getUrl($this['id'] . '/schedules' . $options), $this->_publickey, $this->_secretkey);
+        }
+    }
+
+    /**
      * @param  string $id
      *
      * @return string

--- a/lib/omise/OmiseSchedule.php
+++ b/lib/omise/OmiseSchedule.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+require_once dirname(__FILE__).'/OmiseOccurrenceList.php';
 
 class OmiseSchedule extends OmiseApiResource
 {
@@ -44,6 +45,22 @@ class OmiseSchedule extends OmiseApiResource
     public static function create($params, $publickey = null, $secretkey = null)
     {
         return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+    }
+
+    /**
+     * @param  array|string $options
+     *
+     * @return OmiseOccurrenceList|null
+     */
+    public function occurrences($options = array())
+    {
+        if ($this['object'] === 'schedule') {
+            if (is_array($options)) {
+                $options = '?' . http_build_query($options);
+            }
+
+            return parent::g_retrieve('OmiseOccurrenceList', self::getUrl($this['id'] . '/occurrences' . $options), $this->_publickey, $this->_secretkey);
+        }
     }
 
     /**

--- a/lib/omise/OmiseSchedule.php
+++ b/lib/omise/OmiseSchedule.php
@@ -1,0 +1,76 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseSchedule extends OmiseApiResource
+{
+    const ENDPOINT = 'schedules';
+
+    /**
+     * Retrieves a schedule.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseSchedule
+     */
+    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * @return void
+     */
+    public function reload()
+    {
+        if ($this['object'] === 'schedule') {
+            parent::g_reload(self::getUrl($this['id']));
+        } else {
+            parent::g_reload(self::getUrl());
+        }
+    }
+
+    /**
+     * Creates a new schedule.
+     *
+     * @param  array  $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseSchedule
+     */
+    public static function create($params, $publickey = null, $secretkey = null)
+    {
+        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+    }
+
+    /**
+     * @return void
+     */
+    public function destroy()
+    {
+        parent::g_destroy(self::getUrl($this['id']));
+    }
+
+    /**
+     * @return bool
+     *
+     * @see    OmiseApiResource::isDestroyed()
+     */
+    public function isDestroyed()
+    {
+        return parent::isDestroyed();
+    }
+
+    /**
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT . '/' . $id;
+    }
+}

--- a/lib/omise/OmiseScheduleList.php
+++ b/lib/omise/OmiseScheduleList.php
@@ -1,0 +1,16 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseScheduleList extends OmiseApiResource
+{
+	/**
+	 * @param  string $id
+	 *
+	 * @return OmiseOccurrence
+	 */
+	public function retrieve($id)
+	{
+	    return OmiseSchedule::retrieve($id, $this->_publickey, $this->_secretkey);
+	}
+}

--- a/lib/omise/OmiseScheduler.php
+++ b/lib/omise/OmiseScheduler.php
@@ -1,0 +1,193 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseScheduler extends OmiseApiResource
+{
+    private $attributes = array();
+
+    /**
+     * Create an instance of `OmiseScheduler` with the given type.
+     *
+     * @param string $type        Either 'charge' or 'transfer'
+     * @param string $attributes  See supported attributes at [Charge Schedule API](https://www.omise.co/charge-schedules-api#charge_schedules-create) page.
+     * @param string $publickey
+     * @param string $secretkey
+     */
+    public function __construct($type, $attributes = array(), $publickey = null, $secretkey = null)
+    {
+        parent::__construct($publickey, $secretkey);
+
+        $this->mergeAttributes($type, $attributes);
+    }
+
+    /**
+     * @param  int $frequency
+     *
+     * @return self
+     */
+    public function every($frequency)
+    {
+        return $this->mergeAttributes('every', $frequency);
+    }
+
+    /**
+     * @return self
+     */
+    public function days()
+    {
+        return $this->mergeAttributes('period', 'day');
+    }
+
+    /**
+     * Alias of OmiseScheduler::days()
+     *
+     * @return self
+     *
+     * @see    OmiseScheduler::days()
+     */
+    public function day()
+    {
+        return $this->days();
+    }
+
+    /**
+     * @param  string|array $on  An array (or string) of weekday names. ('Monday' ... 'Sunday')
+     *
+     * @return self
+     */
+    public function weeks($on)
+    {
+        return $this->mergeAttributes('period', 'week')
+                    ->mergeAttributes('on', array('weekdays' => is_string($on) ? array($on) : $on));
+    }
+
+    /**
+     * Alias of OmiseScheduler::weeks($on)
+     *
+     * @return self
+     *
+     * @see    OmiseScheduler::weeks($on)
+     */
+    public function week($on)
+    {
+        return $this->weeks($on);
+    }
+
+    /**
+     * @param  string|array $on  Be an Array if set to 'days of month'. i.e. [1, 15, 25]
+     *                           and a string when set to 'weekday of month'.
+     *                           i.e. 'first_monday', 'second_monday', 'third_monday', 'fourth_monday', 'last_monday'
+     *
+     * @return self
+     */
+    public function months($on)
+    {
+        $this->mergeAttributes('period', 'month');
+
+        switch (strtolower(gettype($on))) {
+            case 'string':
+                return $this->mergeAttributes('on', array('weekday_of_month' => $on));
+                break;
+
+            case 'array':
+                return $this->mergeAttributes('on', array('days_of_month' => $on));
+                break;
+
+            case 'integer':
+                return $this->mergeAttributes('on', array('days_of_month' => array($on)));
+                break;
+
+            default:
+                throw new OmiseBadRequestException("The first argument must be an Array or a String, not " . gettype($on), 1);
+                break;
+        }
+    }
+
+    /**
+     * Alias of OmiseScheduler::months($on)
+     *
+     * @return self
+     *
+     * @see    OmiseScheduler::months($on)
+     */
+    public function month($on)
+    {
+        return $this->months($on);
+    }
+
+    /**
+     * @param  Date $date  [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (YYYY-MM-DD).
+     *
+     * @return self
+     */
+    public function endDate($date)
+    {
+        return $this->mergeAttributes('end_date', $date);
+    }
+
+    /**
+     * @param  Date $date  [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format (YYYY-MM-DD).
+     *
+     * @return self
+     */
+    public function startDate($date)
+    {
+        return $this->mergeAttributes('start_date', $date);
+    }
+
+    /**
+     * Start create a schedule
+     *
+     * @return OmiseSchedule
+     */
+    public function start()
+    {
+        return OmiseSchedule::create($this->attributes, $this->_publickey, $this->_secretkey);
+    }
+
+    /**
+     * Merge the given key and value to attributes.
+     *
+     * @param  string $key    attribute key.
+     * @param  mixed  $value  attribute value.
+     *
+     * @return self
+     */
+    private function mergeAttributes($key, $value)
+    {
+        $this->attributes[$key] = $value;
+
+        return $this;
+    }
+
+    /** Override methods of ArrayAccess **/
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see OmiseObject::offsetExists()
+     */
+    public function offsetExists($key)
+    {
+        if (isset($this->attributes[$key])) {
+            return true;
+        }
+
+        return parent::offsetExists($key);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see OmiseObject::offsetGet()
+     */
+    public function offsetGet($key)
+    {
+        if (isset($this->attributes[$key])) {
+            return $this->attributes[$key];
+        }
+
+        return parent::offsetGet($key);
+    }
+}

--- a/lib/omise/OmiseTransfer.php
+++ b/lib/omise/OmiseTransfer.php
@@ -2,6 +2,8 @@
 
 require_once dirname(__FILE__).'/res/OmiseApiResource.php';
 
+require_once dirname(__FILE__).'/OmiseScheduleList.php';
+
 class OmiseTransfer extends OmiseApiResource
 {
     const ENDPOINT = 'transfers';
@@ -78,6 +80,24 @@ class OmiseTransfer extends OmiseApiResource
     protected function update($params)
     {
         parent::g_update(self::getUrl($this['id']), $params);
+    }
+
+    /**
+     * Gets a list of transfer schedules.
+     *
+     * @param  array|string $options
+     * @param  string       $publickey
+     * @param  string       $secretkey
+     *
+     * @return OmiseScheduleList
+     */
+    public static function schedules($options = array(), $publickey = null, $secretkey = null)
+    {
+        if (is_array($options)) {
+            $options = '?' . http_build_query($options);
+        }
+
+        return parent::g_retrieve('OmiseScheduleList', self::getUrl('schedules' . $options), $publickey, $secretkey);
     }
 
     /**

--- a/lib/omise/OmiseTransfer.php
+++ b/lib/omise/OmiseTransfer.php
@@ -37,6 +37,20 @@ class OmiseTransfer extends OmiseApiResource
     }
 
     /**
+     * Schedule a transfer.
+     *
+     * @param  string $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseScheduler
+     */
+    public static function schedule($params, $publickey = null, $secretkey = null)
+    {
+        return new OmiseScheduler('transfer', $params, $publickey, $secretkey);
+    }
+
+    /**
      * Creates a transfer.
      *
      * @param  mixed  $params

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -293,7 +293,10 @@ class OmiseApiResource extends OmiseObject
 
         // Also merge POST parameters with the option.
         if (count($params) > 0) {
-            $options += array(CURLOPT_POSTFIELDS => http_build_query($params));
+            $http_query = http_build_query($params);
+            $http_query = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $http_query);
+
+            $options += array(CURLOPT_POSTFIELDS => $http_query);
         }
 
         return $options;

--- a/tests/fixtures/api.omise.co/charges/schedules-get.json
+++ b/tests/fixtures/api.omise.co/charges/schedules-get.json
@@ -1,0 +1,22 @@
+{
+  "object": "list",
+  "from": "1970-01-01T00:00:00+00:00",
+  "to": "2017-06-01T14:31:03+00:00",
+  "offset": 0,
+  "limit": 20,
+  "total": 10,
+  "order": "chronological",
+  "location": "/schedules",
+  "data": [
+  	{
+      "object": "schedule",
+      "charge": {
+        "amount": 100000,
+        "currency": "thb",
+        "description": "Membership Fee",
+        "customer": "cust_test_585t0gn3yxe6aeq9wq7",
+        "card": null
+      }
+  	}
+  ]
+}

--- a/tests/fixtures/api.omise.co/customers/cust_test_5234fzk37pi2mz0cen3/schedules-get.json
+++ b/tests/fixtures/api.omise.co/customers/cust_test_5234fzk37pi2mz0cen3/schedules-get.json
@@ -1,0 +1,22 @@
+{
+  "object": "list",
+  "from": "1970-01-01T00:00:00+00:00",
+  "to": "2017-06-01T14:31:03+00:00",
+  "offset": 0,
+  "limit": 20,
+  "total": 10,
+  "order": "chronological",
+  "location": "/schedules",
+  "data": [
+  	{
+      "object": "schedule",
+      "charge": {
+        "amount": 100000,
+        "currency": "thb",
+        "description": "Membership Fee",
+        "customer": "cust_test_5234fzk37pi2mz0cen3",
+        "card": null
+      }
+  	}
+  ]
+}

--- a/tests/fixtures/api.omise.co/occurrences/occu_test_58dt3strf4m1y7bqii8-get.json
+++ b/tests/fixtures/api.omise.co/occurrences/occu_test_58dt3strf4m1y7bqii8-get.json
@@ -1,0 +1,14 @@
+{
+  "object": "occurrence",
+  "id": "occu_test_58dt3strf4m1y7bqii8",
+  "livemode": false,
+  "location": "/occurrences/occu_test_58dt3strf4m1y7bqii8",
+  "schedule": "schd_test_58dt3stpi3ctdbirc98",
+  "schedule_date": "2017-06-22",
+  "retry_date": null,
+  "processed_at": "2017-06-21T22:04:03Z",
+  "status": "successful",
+  "message": null,
+  "result": "trsf_test_58dt3su96b9tpk4nmjm",
+  "created": "2017-06-21T22:04:03Z"
+}

--- a/tests/fixtures/api.omise.co/recipients/recp_test_508a9dytz793gxv9m77/schedules-get.json
+++ b/tests/fixtures/api.omise.co/recipients/recp_test_508a9dytz793gxv9m77/schedules-get.json
@@ -1,0 +1,21 @@
+{
+  "object": "list",
+  "from": "1970-01-01T00:00:00+00:00",
+  "to": "2017-06-01T14:31:03+00:00",
+  "offset": 0,
+  "limit": 20,
+  "total": 10,
+  "order": "chronological",
+  "location": "/schedules",
+  "data": [
+  	{
+      "object": "schedule",
+      "transfer": {
+        "recipient": "recp_test_508a9dytz793gxv9m77",
+        "amount": null,
+        "percentage_of_balance": 0.05,
+        "currency": "thb"
+      }
+  	}
+  ]
+}

--- a/tests/fixtures/api.omise.co/schedules-get.json
+++ b/tests/fixtures/api.omise.co/schedules-get.json
@@ -1,0 +1,15 @@
+{
+  "object": "list",
+  "from": "1970-01-01T00:00:00+00:00",
+  "to": "2017-06-01T14:31:03+00:00",
+  "offset": 0,
+  "limit": 20,
+  "total": 10,
+  "order": "chronological",
+  "location": "/schedules",
+  "data": [
+  	{
+      "object": "schedule"
+  	}
+  ]
+}

--- a/tests/fixtures/api.omise.co/schedules-post.json
+++ b/tests/fixtures/api.omise.co/schedules-post.json
@@ -1,0 +1,53 @@
+{
+  "object": "schedule",
+  "id": "schd_test_585v26u9n5b7e58uhcz",
+  "livemode": false,
+  "location": "/schedules/schd_test_585v26u9n5b7e58uhcz",
+  "status": "active",
+  "deleted": false,
+  "every": 7,
+  "period": "day",
+  "on": {
+  },
+  "in_words": "Every 7 day(s)",
+  "start_date": "2017-06-01",
+  "end_date": "2020-12-01",
+  "charge": {
+    "amount": 100000,
+    "currency": "thb",
+    "description": "Membership Fee",
+    "customer": "cust_test_585t0gn3yxe6aeq9wq7",
+    "card": null
+  },
+  "occurrences": {
+    "object": "list",
+    "from": "1970-01-01T00:00:00+00:00",
+    "to": "2017-06-01T14:31:03+00:00",
+    "offset": 0,
+    "limit": 20,
+    "total": 1,
+    "order": null,
+    "location": "/schedules/schd_test_585v26u9n5b7e58uhcz/occurrences",
+    "data": [
+      {
+        "object": "occurrence",
+        "id": "occu_test_585v26uapowj60lhif4",
+        "location": "/occurrences/occu_test_585v26uapowj60lhif4",
+        "schedule": "schd_test_585v26u9n5b7e58uhcz",
+        "schedule_date": "2017-06-01",
+        "retry_date": null,
+        "processed_at": "2017-06-01T14:31:03Z",
+        "status": "successful",
+        "message": null,
+        "result": "chrg_test_585v26ukjt04m1ok7mc",
+        "created": "2017-06-01T14:31:02Z"
+      }
+    ]
+  },
+  "next_occurrence_dates": [
+    "2017-06-08",
+    "2017-06-15",
+    "2017-06-22"
+  ],
+  "created": "2017-06-01T14:31:02Z"
+}

--- a/tests/fixtures/api.omise.co/schedules/schd_test_585t7iomh2dte3ejxh5-delete.json
+++ b/tests/fixtures/api.omise.co/schedules/schd_test_585t7iomh2dte3ejxh5-delete.json
@@ -1,0 +1,8 @@
+{
+  "object": "schedule",
+  "id": "schd_test_585t7iomh2dte3ejxh5",
+  "livemode": false,
+  "location": "/schedules/schd_test_585t7iomh2dte3ejxh5",
+  "status": "deleted",
+  "deleted": true
+}

--- a/tests/fixtures/api.omise.co/schedules/schd_test_585t7iomh2dte3ejxh5-get.json
+++ b/tests/fixtures/api.omise.co/schedules/schd_test_585t7iomh2dte3ejxh5-get.json
@@ -1,0 +1,4 @@
+{
+  "object": "schedule",
+  "id": "schd_test_585t7iomh2dte3ejxh5"
+}

--- a/tests/fixtures/api.omise.co/schedules/schd_test_585t7iomh2dte3ejxh5/occurrences-get.json
+++ b/tests/fixtures/api.omise.co/schedules/schd_test_585t7iomh2dte3ejxh5/occurrences-get.json
@@ -1,0 +1,9 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "occurrence",
+      "id": "occu_test_58dt3strf4m1y7bqii8"
+    }
+  ]
+}

--- a/tests/fixtures/api.omise.co/transfers/schedules-get.json
+++ b/tests/fixtures/api.omise.co/transfers/schedules-get.json
@@ -1,0 +1,21 @@
+{
+  "object": "list",
+  "from": "1970-01-01T00:00:00+00:00",
+  "to": "2017-06-01T14:31:03+00:00",
+  "offset": 0,
+  "limit": 20,
+  "total": 10,
+  "order": "chronological",
+  "location": "/schedules",
+  "data": [
+  	{
+      "object": "schedule",
+      "transfer": {
+        "recipient": "recp_test_586lkjci7y1h3a0uce3",
+        "amount": null,
+        "percentage_of_balance": 0.05,
+        "currency": "thb"
+      }
+  	}
+  ]
+}

--- a/tests/omise/ChargeTest.php
+++ b/tests/omise/ChargeTest.php
@@ -125,4 +125,17 @@ class ChargeTest extends TestConfig {
       $this->assertEquals('charge', $item['object']);
     }
   }
+
+  /**
+   * @test
+   */
+  public function retrieve_schedules()
+  {
+    $schedules = OmiseCharge::schedules();
+
+    $this->assertArrayHasKey('object', $schedules);
+    $this->assertEquals('list', $schedules['object']);
+    $this->assertEquals('schedule', $schedules['data'][0]['object']);
+    $this->assertArrayHasKey('charge', $schedules['data'][0]);
+  }
 }

--- a/tests/omise/ChargeTest.php
+++ b/tests/omise/ChargeTest.php
@@ -138,4 +138,19 @@ class ChargeTest extends TestConfig {
     $this->assertEquals('schedule', $schedules['data'][0]['object']);
     $this->assertArrayHasKey('charge', $schedules['data'][0]);
   }
+
+  /**
+   * @test
+   */
+  public function create_scheduler()
+  {
+    $charge = array(
+      'customer' => 'cust_test_58e7azwu6owk31ok81y',
+      'amount'   => 99900
+    );
+
+    $scheduler = OmiseCharge::schedule($charge);
+
+    $this->assertEquals($charge, $scheduler['charge']);
+  }
 }

--- a/tests/omise/CustomerTest.php
+++ b/tests/omise/CustomerTest.php
@@ -108,4 +108,19 @@ class CustomerTest extends TestConfig {
       $this->assertEquals('customer', $item['object']);
     }
   }
+
+  /**
+   * @test
+   */
+  public function retrieve_schedules()
+  {
+    $customer  = OmiseCustomer::retrieve('cust_test_5234fzk37pi2mz0cen3');
+    $schedules = $customer->schedules();
+
+    $this->assertArrayHasKey('object', $schedules);
+    $this->assertEquals('list', $schedules['object']);
+    $this->assertEquals('schedule', $schedules['data'][0]['object']);
+    $this->assertArrayHasKey('charge', $schedules['data'][0]);
+    $this->assertEquals('cust_test_5234fzk37pi2mz0cen3', $schedules['data'][0]['charge']['customer']);
+  }
 }

--- a/tests/omise/OccurrenceTest.php
+++ b/tests/omise/OccurrenceTest.php
@@ -1,0 +1,40 @@
+<?php
+require_once dirname(__FILE__).'/TestConfig.php';
+
+class OccurrenceTest extends TestConfig
+{
+    /**
+     * @test
+     */
+    public function existing_methods()
+    {
+        $this->assertTrue(method_exists('OmiseOccurrence', 'retrieve'));
+        $this->assertTrue(method_exists('OmiseOccurrence', 'getUrl'));
+    }
+
+    /**
+     * @test
+     */
+    public function retrieve_by_a_given_id()
+    {
+        $id = 'occu_test_58dt3strf4m1y7bqii8';
+
+        $occurrence = OmiseOccurrence::retrieve($id);
+
+        $this->assertArrayHasKey('object', $occurrence);
+        $this->assertEquals('occurrence', $occurrence['object']);
+        $this->assertEquals($occurrence['id'], $id);
+    }
+
+    /**
+     * @test
+     */
+    public function reload()
+    {
+        $occurrence = OmiseOccurrence::retrieve('occu_test_58dt3strf4m1y7bqii8');
+        $occurrence->reload();
+
+        $this->assertArrayHasKey('object', $occurrence);
+        $this->assertEquals('occurrence', $occurrence['object']);
+    }
+}

--- a/tests/omise/RecipientTest.php
+++ b/tests/omise/RecipientTest.php
@@ -91,4 +91,19 @@ class OmiseRecipientTest extends TestConfig {
       $this->assertEquals('recipient', $item['object']);
     }
   }
+
+  /**
+   * @test
+   */
+  public function retrieve_schedules()
+  {
+    $recipient  = OmiseRecipient::retrieve('recp_test_508a9dytz793gxv9m77');
+    $schedules = $recipient->schedules();
+
+    $this->assertArrayHasKey('object', $schedules);
+    $this->assertEquals('list', $schedules['object']);
+    $this->assertEquals('schedule', $schedules['data'][0]['object']);
+    $this->assertArrayHasKey('transfer', $schedules['data'][0]);
+    $this->assertEquals('recp_test_508a9dytz793gxv9m77', $schedules['data'][0]['transfer']['recipient']);
+  }
 }

--- a/tests/omise/ScheduleTest.php
+++ b/tests/omise/ScheduleTest.php
@@ -99,6 +99,40 @@ class ScheduleTest extends TestConfig
     /**
      * @test
      */
+    public function retrieve_occurrences_list()
+    {
+        $schedule    = OmiseSchedule::retrieve('schd_test_585t7iomh2dte3ejxh5');
+        $occurrences = $schedule->occurrences();
+
+        $this->assertArrayHasKey('object', $occurrences);
+        $this->assertEquals('list', $occurrences['object']);
+    }
+
+    /**
+     * @test
+     */
+    public function retrieve_occurrences_by_a_given_id()
+    {
+        $schedule   = OmiseSchedule::retrieve('schd_test_585t7iomh2dte3ejxh5');
+        $occurrence = $schedule->occurrences()->retrieve('occu_test_58dt3strf4m1y7bqii8');
+
+        $this->assertArrayHasKey('object', $occurrence);
+        $this->assertEquals('occurrence', $occurrence['object']);
+    }
+
+    /**
+     * @test
+     */
+    public function retrieve_null_occurrence()
+    {
+        $schedules = OmiseSchedule::retrieve();
+
+        $this->assertNull($schedules->occurrences());
+    }
+
+    /**
+     * @test
+     */
     public function destroy()
     {
         $schedule = OmiseSchedule::retrieve('schd_test_585t7iomh2dte3ejxh5');

--- a/tests/omise/ScheduleTest.php
+++ b/tests/omise/ScheduleTest.php
@@ -1,0 +1,110 @@
+<?php
+require_once dirname(__FILE__).'/TestConfig.php';
+
+class ScheduleTest extends TestConfig
+{
+    /**
+     * @test
+     */
+    public function existing_methods()
+    {
+        $this->assertTrue(method_exists('OmiseSchedule', 'retrieve'));
+        $this->assertTrue(method_exists('OmiseSchedule', 'reload'));
+        $this->assertTrue(method_exists('OmiseSchedule', 'create'));
+        $this->assertTrue(method_exists('OmiseSchedule', 'destroy'));
+        $this->assertTrue(method_exists('OmiseSchedule', 'isDestroyed'));
+        $this->assertTrue(method_exists('OmiseSchedule', 'getUrl'));
+    }
+
+    /**
+     * @test
+     */
+    public function create()
+    {
+        $customer = array(
+            'customer'    => 'cust_test_585t0gn3yxe6aeq9wq7',
+            'amount'      => 100000,
+            'description' => 'Membership Fee',
+        );
+        $endDate = '2020-12-01';
+
+        $schedule = OmiseSchedule::create(array(
+            'charge'   => $customer,
+            'every'    => 7,
+            'period'   => 'day',
+            'end_date' => $endDate
+        ));
+
+        $this->assertArrayHasKey('object', $schedule);
+        $this->assertEquals('schedule', $schedule['object']);
+        $this->assertEquals($schedule['every'], 7);
+        $this->assertEquals($schedule['period'], 'day');
+        $this->assertEquals($schedule['end_date'], $endDate);
+    }
+
+    /**
+     * @test
+     */
+    public function retrieve_list()
+    {
+        $schedules = OmiseSchedule::retrieve();
+
+        $this->assertArrayHasKey('object', $schedules);
+        $this->assertEquals('list', $schedules['object']);
+        $this->assertEquals('schedule', $schedules['data'][0]['object']);
+    }
+
+    /**
+     * @test
+     */
+    public function reload_list()
+    {
+        $schedules = OmiseSchedule::retrieve();
+        $schedules->reload();
+
+        $this->assertArrayHasKey('object', $schedules);
+        $this->assertEquals('list', $schedules['object']);
+        $this->assertEquals('schedule', $schedules['data'][0]['object']);
+    }
+
+    /**
+     * @test
+     */
+    public function retrieve_by_a_given_id()
+    {
+        $id = 'schd_test_585t7iomh2dte3ejxh5';
+
+        $schedule = OmiseSchedule::retrieve($id);
+
+        $this->assertArrayHasKey('object', $schedule);
+        $this->assertEquals('schedule', $schedule['object']);
+        $this->assertEquals($id, $schedule['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function reload()
+    {
+        $id = 'schd_test_585t7iomh2dte3ejxh5';
+
+        $schedule = OmiseSchedule::retrieve($id);
+        $schedule->reload();
+
+        $this->assertArrayHasKey('object', $schedule);
+        $this->assertEquals('schedule', $schedule['object']);
+        $this->assertEquals($id, $schedule['id']);
+    }
+
+    /**
+     * @test
+     */
+    public function destroy()
+    {
+        $schedule = OmiseSchedule::retrieve('schd_test_585t7iomh2dte3ejxh5');
+        $schedule->destroy();
+
+        $this->assertArrayHasKey('object', $schedule);
+        $this->assertTrue($schedule->isDestroyed());
+    }
+}

--- a/tests/omise/SchedulerTest.php
+++ b/tests/omise/SchedulerTest.php
@@ -1,0 +1,190 @@
+<?php
+require_once dirname(__FILE__).'/TestConfig.php';
+
+class SchedulerTest extends TestConfig
+{
+    /**
+     * @test
+     */
+    public function existing_methods()
+    {
+        $this->assertTrue(method_exists('OmiseScheduler', 'every'));
+        $this->assertTrue(method_exists('OmiseScheduler', 'days'));
+        $this->assertTrue(method_exists('OmiseScheduler', 'day'));
+        $this->assertTrue(method_exists('OmiseScheduler', 'weeks'));
+        $this->assertTrue(method_exists('OmiseScheduler', 'week'));
+        $this->assertTrue(method_exists('OmiseScheduler', 'months'));
+        $this->assertTrue(method_exists('OmiseScheduler', 'month'));
+        $this->assertTrue(method_exists('OmiseScheduler', 'endDate'));
+        $this->assertTrue(method_exists('OmiseScheduler', 'startDate'));
+        $this->assertTrue(method_exists('OmiseScheduler', 'start'));
+    }
+
+    /**
+     * @test
+     */
+    public function create_a_charge_scheduler()
+    {
+        $charge = array(
+            'customer'    => 'cust_test_5234fzk37pi2mz0cen3',
+            'amount'      => 99900,
+            'description' => 'Membership Fee'
+        );
+
+        $scheduler = new OmiseScheduler('charge', $charge);
+
+        $this->assertEquals($charge, $scheduler['charge']);
+    }
+
+    /**
+     * @test
+     */
+    public function create_a_transfer_scheduler()
+    {
+        $transfer = array(
+            'recipient' => 'recp_test_508a9dytz793gxv9m77',
+            'amount'    => 100000
+        );
+
+        $scheduler = new OmiseScheduler('transfer', $transfer);
+
+        $this->assertEquals($transfer, $scheduler['transfer']);
+    }
+
+    /**
+     * @test
+     */
+    public function set_scheduler_to_perform_every_15_days()
+    {
+        $charge = array(
+            'customer'    => 'cust_test_5234fzk37pi2mz0cen3',
+            'amount'      => 99900,
+            'description' => 'Membership Fee'
+        );
+
+        $scheduler = new OmiseScheduler('charge', $charge);
+        $scheduler
+            ->every(15)
+            ->days();
+
+        $this->assertEquals($charge, $scheduler['charge']);
+        $this->assertEquals(15, $scheduler['every']);
+        $this->assertEquals('day', $scheduler['period']);
+    }
+
+    /**
+     * @test
+     */
+    public function set_scheduler_to_perform_every_2_weeks_on_monday()
+    {
+        $charge = array(
+            'customer'    => 'cust_test_5234fzk37pi2mz0cen3',
+            'amount'      => 99900,
+            'description' => 'Membership Fee'
+        );
+
+        $scheduler = new OmiseScheduler('charge', $charge);
+        $scheduler
+            ->every(2)
+            ->weeks('Monday');
+
+        $this->assertEquals($charge, $scheduler['charge']);
+        $this->assertEquals(2, $scheduler['every']);
+        $this->assertEquals('week', $scheduler['period']);
+        $this->assertEquals(array('weekdays' => array('Monday')), $scheduler['on']);
+    }
+
+    /**
+     * @test
+     */
+    public function set_scheduler_to_perform_every_1_month_on_first_and_fifteenth()
+    {
+        $charge = array(
+            'customer'    => 'cust_test_5234fzk37pi2mz0cen3',
+            'amount'      => 99900,
+            'description' => 'Membership Fee'
+        );
+
+        $scheduler = new OmiseScheduler('charge', $charge);
+        $scheduler
+            ->every(1)
+            ->month(array(1, 15));
+
+        $this->assertEquals($charge, $scheduler['charge']);
+        $this->assertEquals(1, $scheduler['every']);
+        $this->assertEquals('month', $scheduler['period']);
+        $this->assertEquals(array('days_of_month' => array(1, 15)), $scheduler['on']);
+    }
+
+    /**
+     * @test
+     */
+    public function set_scheduler_to_perform_every_3_months_on_twentyeighth()
+    {
+        $charge = array(
+            'customer'    => 'cust_test_5234fzk37pi2mz0cen3',
+            'amount'      => 99900,
+            'description' => 'Membership Fee'
+        );
+
+        $scheduler = new OmiseScheduler('charge', $charge);
+        $scheduler
+            ->every(3)
+            ->month(28);
+
+        $this->assertEquals($charge, $scheduler['charge']);
+        $this->assertEquals(3, $scheduler['every']);
+        $this->assertEquals('month', $scheduler['period']);
+        $this->assertEquals(array('days_of_month' => array(28)), $scheduler['on']);
+    }
+
+    /**
+     * @test
+     */
+    public function set_scheduler_to_perform_every_1_month_on_last_friday_and_specify_end_date()
+    {
+        $charge = array(
+            'customer'    => 'cust_test_5234fzk37pi2mz0cen3',
+            'amount'      => 99900,
+            'description' => 'Membership Fee'
+        );
+
+        $scheduler = new OmiseScheduler('charge', $charge);
+        $scheduler
+            ->every(1)
+            ->month('last_friday')
+            ->endDate('2020-01-01');
+
+        $this->assertEquals($charge, $scheduler['charge']);
+        $this->assertEquals(1, $scheduler['every']);
+        $this->assertEquals('month', $scheduler['period']);
+        $this->assertEquals(array('weekday_of_month' => 'last_friday'), $scheduler['on']);
+        $this->assertEquals('2020-01-01', $scheduler['end_date']);
+    }
+
+    /**
+     * @test
+     */
+    public function set_scheduler_to_perform_at_specific_date()
+    {
+        $charge = array(
+            'customer'    => 'cust_test_5234fzk37pi2mz0cen3',
+            'amount'      => 99900,
+            'description' => 'Membership Fee'
+        );
+
+        $scheduler = new OmiseScheduler('charge', $charge);
+        $scheduler
+            ->every(1)
+            ->month('last_friday')
+            ->endDate('2020-01-01')
+            ->startDate('2019-01-01');
+
+        $this->assertEquals($charge, $scheduler['charge']);
+        $this->assertEquals(1, $scheduler['every']);
+        $this->assertEquals('month', $scheduler['period']);
+        $this->assertEquals(array('weekday_of_month' => 'last_friday'), $scheduler['on']);
+        $this->assertEquals('2020-01-01', $scheduler['end_date']);
+        $this->assertEquals('2019-01-01', $scheduler['start_date']);
+    }
+}

--- a/tests/omise/TransferTest.php
+++ b/tests/omise/TransferTest.php
@@ -89,4 +89,17 @@ class TransferTest extends TestConfig {
       $this->assertEquals('transfer', $item['object']);
     }
   }
+
+  /**
+   * @test
+   */
+  public function retrieve_schedules()
+  {
+    $schedules = OmiseTransfer::schedules();
+
+    $this->assertArrayHasKey('object', $schedules);
+    $this->assertEquals('list', $schedules['object']);
+    $this->assertEquals('schedule', $schedules['data'][0]['object']);
+    $this->assertArrayHasKey('transfer', $schedules['data'][0]);
+  }
 }

--- a/tests/omise/TransferTest.php
+++ b/tests/omise/TransferTest.php
@@ -102,4 +102,19 @@ class TransferTest extends TestConfig {
     $this->assertEquals('schedule', $schedules['data'][0]['object']);
     $this->assertArrayHasKey('transfer', $schedules['data'][0]);
   }
+
+  /**
+   * @test
+   */
+  public function create_scheduler()
+  {
+    $transfer = array(
+      'recipient' => 'recp_test_508a9dytz793gxv9m77',
+      'amount'    => 100000
+    );
+
+    $scheduler = OmiseTransfer::schedule($transfer);
+
+    $this->assertEquals($transfer, $scheduler['transfer']);
+  }
 }


### PR DESCRIPTION
#### 1. Objective

Support Omise schedule APIs.

#### 2. Description of change

Support for these new endpoints.

 verb   | endpoint                           | Description
------- | ---------------------------------- | ---------
GET     | /schedules                         | Retrieve schedule list.
POST    | /schedules                         | Create a new schedule.
GET     | /schedules/SCHEDULE_ID             | Retrieve a schedule by the given id.
DELETE  | /schedules/SCHEDULE_ID             | Delete a schedule by the given id.
GET     | /charges/schedules                 | Retrieve a charge schedule list
GET     | /customer/CUSTOMER_ID/schedules    | Retrieve a charge schedule that belong to the given customer id.
GET     | /transfer/schedules                | Retrieve a transfer schedule list
GET     | /recipients/RECIPIENT_ID/schedules | Retrieve a transfer schedule that belong to the given recipient id.
GET     | schedules/SCHEDULE_ID/occurrences  | Retrieve an occurrence list that belongs to the given schedule id.
GET     | occurrences/OCCURRENCE_ID          | Retrieve an occurrence by the given occurrence id.

#### 3. Quality assurance

3.1 In order to create a new charge schedule, you can use the following code.

```php
$scheduler = OmiseCharge::schedule(
    array(
        'amount' => 77700,
        'customer' => 'cust_test_58e7b94d2wfmfn6p2x1'
    )
);

$schedule = $scheduler->every(1)
                      ->months('first_monday')
                      ->endDate('2017-08-30')
                      ->start();
```

3.2. In order to create a new transfer schedule, you can use the following code.

```php
$scheduler = OmiseTransfer::schedule(
    array(
        'amount' => 77700,
        'recipient' => 'recp_test_586lkjci7y1h3a0uce3'
    )
);

$schedule = $scheduler->every(15)
                      ->days()
                      ->endDate('2017-09-01')
                      ->start();
```

3.3. Test nested resources to get a transfer schedule's occurrence by the following code

```php
// Retrieve recipient.
$recipient    = OmiseRecipient::retrieve('recp_test_586lkjci7y1h3a0uce3');

// Retrieve a schedule list that belong to the given recipient id.
$schedules   = $recipient->schedules(['order'=>'reverse_chronological', 'limit' => 3]);

// Retrieve a schedule
$schedule    = $schedules->retrieve($schedules['data'][0]['id']);

// Retrieve an occurrence list that belong to the given schedule id.
$occurrences = $schedule->occurrences(['order'=>'reverse_chronological', 'limit' => 3]);

// // Retrieve an occurrence.
$occurrence  = $occurrences->retrieve('occu_test_58ejq1gijt8m0wzgmwz');

echo '<pre>';
print_r($occurrence);
echo '</pre>'; 

// OR without nested resources.

$occurrence = OmiseOccurrence::retrieve('occu_test_58ejq1gijt8m0wzgmwz');
```

#### 4. Impact of the change

No.

#### 5. Additional notes

No.
