### PR TITLE
Support Forex APIs.

### DIFF
--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -6,6 +6,7 @@ require_once dirname(__FILE__).'/omise/OmiseCard.php';
 require_once dirname(__FILE__).'/omise/OmiseCardList.php';
 require_once dirname(__FILE__).'/omise/OmiseDispute.php';
 require_once dirname(__FILE__).'/omise/OmiseEvent.php';
+require_once dirname(__FILE__).'/omise/OmiseForex.php';
 require_once dirname(__FILE__).'/omise/OmiseToken.php';
 require_once dirname(__FILE__).'/omise/OmiseCharge.php';
 require_once dirname(__FILE__).'/omise/OmiseCustomer.php';

--- a/lib/omise/OmiseForex.php
+++ b/lib/omise/OmiseForex.php
@@ -1,0 +1,40 @@
+<?php
+
+require_once dirname(__FILE__).'/res/OmiseApiResource.php';
+
+class OmiseForex extends OmiseApiResource
+{
+    const ENDPOINT = 'forex';
+
+    /**
+     * Retrieves a forex data.
+     *
+     * @param  string $currency
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseForex
+     */
+    public static function retrieve($currency = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($currency), $publickey, $secretkey);
+    }
+
+    /**
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        parent::g_reload(self::getUrl($this['from']));
+    }
+
+    /**
+     * @param  string $currency
+     *
+     * @return string
+     */
+    private static function getUrl($currency = '')
+    {
+        return OMISE_API_URL . self::ENDPOINT . '/' . $currency;
+    }
+}

--- a/tests/fixtures/api.omise.co/forex/usd-get.json
+++ b/tests/fixtures/api.omise.co/forex/usd-get.json
@@ -1,0 +1,7 @@
+{
+  "object": "forex",
+  "from": "usd",
+  "to": "thb",
+  "rate": 32.649636125,
+  "location": "/forex/usd"
+}

--- a/tests/omise/ForexTest.php
+++ b/tests/omise/ForexTest.php
@@ -1,0 +1,40 @@
+<?php
+require_once dirname(__FILE__) . '/TestConfig.php';
+
+class ForexTest extends TestConfig
+{
+    /**
+     * @test
+     */
+    public function existing_methods()
+    {
+        $this->assertTrue(method_exists('OmiseSchedule', 'retrieve'));
+        $this->assertTrue(method_exists('OmiseSchedule', 'reload'));
+        $this->assertTrue(method_exists('OmiseSchedule', 'getUrl'));
+    }
+
+    /**
+     * @test
+     */
+    public function retrieve()
+    {
+        $forex = OmiseForex::retrieve('usd');
+
+        $this->assertArrayHasKey('object', $forex);
+        $this->assertEquals('forex', $forex['object']);
+        $this->assertEquals('usd', $forex['from']);
+    }
+
+    /**
+     * @test
+     */
+    public function reload()
+    {
+        $forex = OmiseForex::retrieve('usd');
+        $forex->reload();
+
+        $this->assertArrayHasKey('object', $forex);
+        $this->assertEquals('forex', $forex['object']);
+        $this->assertEquals('usd', $forex['from']);
+    }
+}


### PR DESCRIPTION
#### 1. Objective

Add support for Omise Forex APIs.

#### 2. Description of change

Support for the endpoint:

 verb   | endpoint                           | Description
------- | ---------------------------------- | ---------
GET     | /forex/CURRENCY                    | Retrieve the currency exchange rate.

#### 3. Quality assurance

Try execute

```php
$forex = OmiseForex::retrieve('usd');

// or.

$forex = OmiseForex::retrieve('usd');
$forex->reload();

print_r($forex);
```

**Result**

```php
OmiseForex Object
(
    [OMISE_CONNECTTIMEOUT:OmiseApiResource:private] => 30
    [OMISE_TIMEOUT:OmiseApiResource:private] => 60
    [_values:protected] => Array
        (
            [object] => forex
            [from] => sgd
            [to] => thb
            [rate] => 23.890175545
            [location] => /forex/sgd
        )

    [_secretkey:protected] => skey_test_******
    [_publickey:protected] => pkey_test_******
)
```

#### 4. Impact of the change

No.

#### 5. Additional notes

No.
