### PR TITLE
fix error on count($params)

### DIFF
--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -292,7 +292,7 @@ class OmiseApiResource extends OmiseObject
         }
 
         // Also merge POST parameters with the option.
-        if (count($params) > 0) {
+        if ($params && count($params) > 0) {
             $http_query = http_build_query($params);
             $http_query = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $http_query);
 


### PR DESCRIPTION
Fix problem: count(): Parameter must be an array or an object that implements Countable when using some API e.g. Balance API