### PR TITLE
Be able to limit items that will be shown at the Search Object 

### DIFF
--- a/lib/omise/OmiseSearch.php
+++ b/lib/omise/OmiseSearch.php
@@ -99,6 +99,18 @@ class OmiseSearch extends OmiseApiResource
     }
 
     /**
+     * Update `per_page` parameter.
+     *
+     * @param  int $limit   Number of items that will be shown per page.
+     *
+     * @return OmiseSearch  This instance.
+     */
+    public function per_page($limit)
+    {
+        return $this->mergeAttributes('per_page', $limit);
+    }
+
+    /**
      * Update `order` parameter.
      *
      * @param  string $order  The order of the list returned.

--- a/tests/fixtures/api.omise.co/search-c2NvcGU9Y2hhcmdlJnF1ZXJ5PWRlbW8mcGVyX3BhZ2U9MiZvcmRlcj1yZXZlcnNlX2Nocm9ub2xvZ2ljYWw-get.json
+++ b/tests/fixtures/api.omise.co/search-c2NvcGU9Y2hhcmdlJnF1ZXJ5PWRlbW8mcGVyX3BhZ2U9MiZvcmRlcj1yZXZlcnNlX2Nocm9ub2xvZ2ljYWw-get.json
@@ -1,0 +1,16 @@
+{
+  "object": "search",
+  "order": "reverse_chronological",
+  "scope": "charge",
+  "query": "demo",
+  "filters": {
+  },
+  "page": 1,
+  "per_page": 2,
+  "location": "/search",
+  "total_pages": 0,
+  "total": 0,
+  "data": [
+
+  ]
+}

--- a/tests/omise/SearchTest.php
+++ b/tests/omise/SearchTest.php
@@ -111,4 +111,22 @@ class SearchTest extends TestConfig
         $this->assertEquals('demo', $search['query']);
         $this->assertEquals(array('captured' => 'true'), $search['filters']);
     }
+
+    /**
+     * Assert that items of search object can be shown at a specific amount
+     * given by 'per_page' number.
+     */
+    public function testSetLimit()
+    {
+        $search = OmiseSearch::scope('charge')
+            ->query('demo')
+            ->per_page(2)
+            ->order('reverse_chronological');
+
+        $this->assertArrayHasKey('object', $search);
+        $this->assertEquals('search', $search['object']);
+        $this->assertEquals('charge', $search['scope']);
+        $this->assertEquals('demo', $search['query']);
+        $this->assertEquals(2, $search['per_page']);
+    }
 }


### PR DESCRIPTION
### 1. Objective

There was a new parameter that Omise-PHP hasn't supported yet on the **Search API**.
So, this PR is to support `per_page` attribute on Search API.

### 2. Description of change

- Be able to limit items that will be shown at the Search Object 

### 3. Quality assurance

Execute the following code and check a result:
```php
define('OMISE_PUBLIC_KEY', 'your_pkey');
define('OMISE_SECRET_KEY', 'your_skey');

echo '<pre>';
$search = OmiseCharge::search()->per_page(3);
echo $search['per_page']; // 3
print_r($search['data']); // 3 items in an array
```

### 4. Impact of the change

No.

### 5. Additional notes

Ref: https://www.omise.co/search-api
