### PR TITLE
Centralising all loaders into one file, `lib/Omise.php`.

### DIFF
--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -1,5 +1,12 @@
 <?php
+// Cores and utilities.
+require_once dirname(__FILE__).'/omise/res/obj/OmiseObject.php';
+require_once dirname(__FILE__).'/omise/res/OmiseApiResource.php';
 
+// Errors
+require_once dirname(__FILE__).'/omise/exception/OmiseExceptions.php';
+
+// API Resources.
 require_once dirname(__FILE__).'/omise/OmiseAccount.php';
 require_once dirname(__FILE__).'/omise/OmiseBalance.php';
 require_once dirname(__FILE__).'/omise/OmiseCard.php';
@@ -11,10 +18,12 @@ require_once dirname(__FILE__).'/omise/OmiseToken.php';
 require_once dirname(__FILE__).'/omise/OmiseCharge.php';
 require_once dirname(__FILE__).'/omise/OmiseCustomer.php';
 require_once dirname(__FILE__).'/omise/OmiseOccurrence.php';
+require_once dirname(__FILE__).'/omise/OmiseOccurrenceList.php';
 require_once dirname(__FILE__).'/omise/OmiseRefund.php';
 require_once dirname(__FILE__).'/omise/OmiseRefundList.php';
 require_once dirname(__FILE__).'/omise/OmiseSearch.php';
 require_once dirname(__FILE__).'/omise/OmiseSchedule.php';
+require_once dirname(__FILE__).'/omise/OmiseScheduleList.php';
 require_once dirname(__FILE__).'/omise/OmiseScheduler.php';
 require_once dirname(__FILE__).'/omise/OmiseSource.php';
 require_once dirname(__FILE__).'/omise/OmiseTransfer.php';

--- a/lib/omise/OmiseAccount.php
+++ b/lib/omise/OmiseAccount.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseAccount extends OmiseApiResource
 {
     const ENDPOINT = 'account';

--- a/lib/omise/OmiseBalance.php
+++ b/lib/omise/OmiseBalance.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseBalance extends OmiseApiResource
 {
     const ENDPOINT = 'balance';

--- a/lib/omise/OmiseCard.php
+++ b/lib/omise/OmiseCard.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseCustomer.php';
-
 class OmiseCard extends OmiseApiResource
 {
     const ENDPOINT = 'cards';

--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseCard.php';
-
 class OmiseCardList extends OmiseApiResource
 {
     const ENDPOINT = 'cards';

--- a/lib/omise/OmiseCharge.php
+++ b/lib/omise/OmiseCharge.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseRefundList.php';
-require_once dirname(__FILE__).'/OmiseScheduleList.php';
-
 class OmiseCharge extends OmiseApiResource
 {
     const ENDPOINT = 'charges';

--- a/lib/omise/OmiseCustomer.php
+++ b/lib/omise/OmiseCustomer.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseCardList.php';
-require_once dirname(__FILE__).'/OmiseScheduleList.php';
-
 class OmiseCustomer extends OmiseApiResource
 {
     const ENDPOINT = 'customers';

--- a/lib/omise/OmiseDispute.php
+++ b/lib/omise/OmiseDispute.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseDispute extends OmiseApiResource
 {
     const ENDPOINT = 'disputes';

--- a/lib/omise/OmiseEvent.php
+++ b/lib/omise/OmiseEvent.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseEvent extends OmiseApiResource
 {
     const ENDPOINT = 'events';

--- a/lib/omise/OmiseForex.php
+++ b/lib/omise/OmiseForex.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseForex extends OmiseApiResource
 {
     const ENDPOINT = 'forex';

--- a/lib/omise/OmiseLink.php
+++ b/lib/omise/OmiseLink.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseLink extends OmiseApiResource
 {
     const ENDPOINT = 'links';

--- a/lib/omise/OmiseOccurrence.php
+++ b/lib/omise/OmiseOccurrence.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseOccurrence extends OmiseApiResource
 {
     const ENDPOINT = 'occurrences';

--- a/lib/omise/OmiseOccurrenceList.php
+++ b/lib/omise/OmiseOccurrenceList.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseOccurrenceList extends OmiseApiResource
 {
     /**

--- a/lib/omise/OmiseRecipient.php
+++ b/lib/omise/OmiseRecipient.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseRecipient extends OmiseApiResource
 {
     const ENDPOINT = 'recipients';

--- a/lib/omise/OmiseRefund.php
+++ b/lib/omise/OmiseRefund.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseRefund extends OmiseApiResource
 {
     /**

--- a/lib/omise/OmiseRefundList.php
+++ b/lib/omise/OmiseRefundList.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseRefund.php';
-
 class OmiseRefundList extends OmiseApiResource
 {
     const ENDPOINT = 'refunds';

--- a/lib/omise/OmiseSchedule.php
+++ b/lib/omise/OmiseSchedule.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseOccurrenceList.php';
-
 class OmiseSchedule extends OmiseApiResource
 {
     const ENDPOINT = 'schedules';

--- a/lib/omise/OmiseScheduleList.php
+++ b/lib/omise/OmiseScheduleList.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseScheduleList extends OmiseApiResource
 {
 	/**

--- a/lib/omise/OmiseScheduler.php
+++ b/lib/omise/OmiseScheduler.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseScheduler extends OmiseApiResource
 {
     private $attributes = array();

--- a/lib/omise/OmiseSearch.php
+++ b/lib/omise/OmiseSearch.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 /**
  * This class is not intended to be used directly from client code.
  *

--- a/lib/omise/OmiseSource.php
+++ b/lib/omise/OmiseSource.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-require_once dirname(__FILE__).'/OmiseRefundList.php';
-require_once dirname(__FILE__).'/OmiseScheduleList.php';
-
 class OmiseSource extends OmiseApiResource
 {
     const ENDPOINT = 'sources';

--- a/lib/omise/OmiseTest.php
+++ b/lib/omise/OmiseTest.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseTest extends OmiseApiResource
 {
     /**

--- a/lib/omise/OmiseTransaction.php
+++ b/lib/omise/OmiseTransaction.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
 class OmiseTransaction extends OmiseApiResource
 {
     const ENDPOINT = 'transactions';

--- a/lib/omise/OmiseTransfer.php
+++ b/lib/omise/OmiseTransfer.php
@@ -1,9 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/res/OmiseApiResource.php';
-
-require_once dirname(__FILE__).'/OmiseScheduleList.php';
-
 class OmiseTransfer extends OmiseApiResource
 {
     const ENDPOINT = 'transfers';

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -1,8 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/obj/OmiseObject.php';
-require_once dirname(__FILE__).'/../exception/OmiseExceptions.php';
-
 define('OMISE_PHP_LIB_VERSION', '2.9.1');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');

--- a/lib/omise/res/OmiseVaultResource.php
+++ b/lib/omise/res/OmiseVaultResource.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once dirname(__FILE__).'/OmiseApiResource.php';
-
 class OmiseVaultResource extends OmiseApiResource
 {
     /**


### PR DESCRIPTION
### 1. Objective

This pull request is aiming to clean up the code-base before implement any new features.  

### 2. Description of change

- Remove all class loaders out from the API Resource classes.
- Centralising the loaders into one file, `lib/Omise.php`.

### 3. Quality assurance

Test by executing all related classes.
```php
OmiseAccount::retrieve();
OmiseAccount::retrieve();

OmiseCharge::retrieve();
$charge = OmiseCharge::retrieve('id');
$charge->refunds();

OmiseCustomer::retrieve();
$customer = OmiseCustomer::retrieve('id');
$customer->cards();

OmiseTransfer::retrieve();

OmiseLink::retrieve();

OmiseForex::retrieve('thb');
```

and so on, all should work fine (be able to fetch data from Omise API).

### 4. Impact of the change

No

### 5. Additional notes

No
