### PR TITLE
Upgrade CircleCI to v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,50 @@
+aliases:
+  - &phpunit
+    run: 
+      name: 'PHPUnit'
+      command: |
+        php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+        php -r "if (hash_file('SHA384', 'composer-setup.php') === trim(file_get_contents('https://composer.github.io/installer.sig'))) { echo 'Installer verified'; } else { echo 'Installer invalid'; unlink('composer-setup.php'); } echo PHP_EOL;"
+        php composer-setup.php
+        php -r "unlink('composer-setup.php');"
+        php ./composer.phar install
+        php ./vendor/bin/phpunit tests
+
+version: 2
+jobs:
+  php72:
+    docker:
+      - image: circleci/php:7.2-cli-browsers-legacy
+    steps:
+      - checkout
+      - *phpunit
+
+  php71:
+    docker:
+      - image: circleci/php:7.1-cli-jessie-browsers-legacy
+    steps:
+      - checkout
+      - *phpunit
+
+  php70:
+    docker:
+      - image: circleci/php:7.0-cli-jessie-browsers-legacy
+    steps:
+      - checkout
+      - *phpunit
+
+  php56:
+    docker:
+      - image: circleci/php:5.6.38-cli-jessie-node-browsers
+    steps:
+      - checkout
+      - *phpunit
+
+workflows:
+  version: 2
+  omisephp:
+    jobs:
+      - php72
+      - php71
+      - php70
+      - php56

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,0 @@
-machine:
-  timezone:
-      Asia/Bangkok
-  php:
-      version: 5.3.20
-
-test:
-  override:
-      - php ./vendor/bin/phpunit tests


### PR DESCRIPTION
### 1. Objective
CircleCI now supported for multiple container. This feature allows us, to be able to test Omise-PHP in different environments.

This pull request is aiming to add more machine to test Omise-PHP in a various environment.

### 2. Description of change
- Upgrade CircleCI script, using version 2 

### 3. Quality assurance
All test scripts should work as normal.
Check: https://circleci.com/gh/omise/omise-php

### 4. Impact of the change

There is no container for PHP below v5.6.
(but I'm planing to drop support v5.3 anyway)

### 5. Additional notes

No
