### PR TITLE
Delegate API response handler to a proper class

### DIFF
--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -2,6 +2,7 @@
 // Cores and utilities.
 require_once dirname(__FILE__).'/omise/res/obj/OmiseObject.php';
 require_once dirname(__FILE__).'/omise/res/OmiseApiResource.php';
+require_once dirname(__FILE__).'/omise/Http/Response/Handler.php';
 
 // Errors
 require_once dirname(__FILE__).'/omise/exception/OmiseExceptions.php';

--- a/lib/omise/Http/Response/Handler.php
+++ b/lib/omise/Http/Response/Handler.php
@@ -21,6 +21,10 @@ class Handler
         return $result;
     }
 
+    /**
+     * @param  mixed $result
+     * @return bool
+     */
     public function isJson($result)
     {
         if (is_string($result) && json_decode($result)) {

--- a/lib/omise/Http/Response/Handler.php
+++ b/lib/omise/Http/Response/Handler.php
@@ -1,0 +1,32 @@
+<?php
+namespace Omise\Http\Response;
+
+class Handler
+{
+    /**
+     * @param mixed $result
+     */
+    public function handle($result)
+    {
+        if (! $this->isJson($result)) {
+            throw new \Exception('Unknown error. (Bad Response)');
+        }
+
+        $result = json_decode($result, true);
+
+        if ($result['object'] === 'error') {
+            throw \OmiseException::getInstance($result);
+        }
+
+        return $result;
+    }
+
+    public function isJson($result)
+    {
+        if (is_string($result) && json_decode($result)) {
+            return json_last_error() === JSON_ERROR_NONE;
+        }
+
+        return false;
+    }
+}

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -140,20 +140,8 @@ class OmiseApiResource extends OmiseObject
             $result = $this->_executeCurl($url, $requestMethod, $key, $params);
         }
 
-        // Decode the JSON response as an associative array.
-        $array = json_decode($result, true);
-
-        // If response is invalid or not a JSON.
-        if (count($array) === 0 || ! isset($array['object'])) {
-            throw new Exception('Unknown error. (Bad Response)');
-        }
-
-        // If response is an error object.
-        if ($array['object'] === 'error') {
-            throw OmiseException::getInstance($array);
-        }
-
-        return $array;
+        $responseHandler = new \Omise\Http\Response\Handler;
+        return $responseHandler->handle($result);
     }
 
     /**

--- a/tests/omise/Http/Response/HandlerTest.php
+++ b/tests/omise/Http/Response/HandlerTest.php
@@ -48,4 +48,25 @@ class HandlerTest extends \TestConfig
     {
         $this->responseHandler->handle(100);
     }
+
+    /**
+     * @test
+     * @expectedException \Exception
+     */
+    public function throw_an_exception_if_response_is_a_boolean()
+    {
+        $this->responseHandler->handle(true);
+    }
+
+    /**
+     * @test
+     */
+    public function valid_json_response()
+    {
+        $result = $this->responseHandler->handle('{"object":"account","id":"acct_test"}');
+
+        $this->assertTrue(is_array($result));
+        $this->assertArrayHasKey('id', $result);
+        $this->assertSame($result['id'], 'acct_test');
+    }
 }

--- a/tests/omise/Http/Response/HandlerTest.php
+++ b/tests/omise/Http/Response/HandlerTest.php
@@ -1,0 +1,51 @@
+<?php
+require_once dirname(__FILE__).'/../../TestConfig.php';
+
+class HandlerTest extends \TestConfig
+{
+    /**
+     * @var \Omise\Http\Response\Handler
+     */
+    private $responseHandler;
+
+    public function setUp()
+    {
+        $this->responseHandler = new \Omise\Http\Response\Handler;
+    }
+
+    /**
+     * @test
+     * @expectedException \OmiseUndefinedException
+     */
+    public function handle_an_undefined_error_obbject()
+    {
+        $this->responseHandler->handle('{"object":"error","code":"undefined_one"}');
+    }
+
+    /**
+     * @test
+     * @expectedException \OmiseAuthenticationFailureException
+     */
+    public function handle_an_error_authentication_failure()
+    {
+        $this->responseHandler->handle('{"object":"error","code":"authentication_failure"}');
+    }
+
+    /**
+     * @test
+     * @expectedException \Exception
+     */
+    public function throw_an_exception_if_response_is_a_string()
+    {
+        $this->responseHandler->handle('string');
+    }
+
+    /**
+     * @test
+     * @expectedException \Exception
+     */
+    public function throw_an_exception_if_response_is_a_number()
+    {
+        $this->responseHandler->handle(100);
+    }
+}


### PR DESCRIPTION
> ⚠️ Note, this pull request requires #82 to be merged first.

### 1. Objective

There are a couple reasons that we should have a proper delegated class to handle API response.
1. Improve its testability.
2. Improve its maintainability, single responsibility class. 
3. Prepare for a coming `Http/Requestor` and `Http/Client` structure (decoupling overwhelming functionalities from `OmiseApiResponse`out to proper classes).

This pull request aims to change from an easiest part, to keep a pull request small and easy to review.

### 2. Description of change

- Decoupling a response handler method out to a proper class
- As from the change, now the code is testable.
- Write test scripts.

### 3. Quality assurance

- Please check a test script

### 4. Impact of the change

No longer support for PHP 5.3. (as this pull request is also introducing `namespace` to a class).

### 5. Additional notes

~Nothing.~
Second thought, once merged and everything is done. This one will be released under `Omise-PHP v3.0`.
