### PR TITLE
Adds initial support for capabilitiy api

### DIFF
--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -9,6 +9,7 @@ require_once dirname(__FILE__).'/omise/exception/OmiseExceptions.php';
 // API Resources.
 require_once dirname(__FILE__).'/omise/OmiseAccount.php';
 require_once dirname(__FILE__).'/omise/OmiseBalance.php';
+require_once dirname(__FILE__).'/omise/OmiseCapabilities.php';
 require_once dirname(__FILE__).'/omise/OmiseCard.php';
 require_once dirname(__FILE__).'/omise/OmiseCardList.php';
 require_once dirname(__FILE__).'/omise/OmiseDispute.php';

--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -18,6 +18,53 @@ class OmiseCapabilities extends OmiseApiResource
     }
 
     /**
+     * Retrieves array of payment backends.
+     *    
+     * @return array
+     */
+    public function getBackends() {
+        // check for filters
+        if ($filters = func_get_args()) $filter = self::combineFilters($filters);
+        $res = $this['payment_backends'];
+        array_walk(
+            $res,
+            function($v, $k) use (&$res) {
+                $id = array_keys($v)[0];
+                $res[$k][$id]['_id'] = $id;
+            }
+        );
+        $res = array_map(function($a) { return (object)reset($a);}, $res);
+        return $filter ? array_filter($res, $filter) : $res;
+    }
+
+
+    public static function backendSupportsCurrency($currency) {
+        return function($backend) use ($currency) { return in_array($currency, $backend->currencies); };
+    }
+
+    public static function backendTypeIs($type) {
+        return function($backend) use ($type) { return $backend->type==$type; };
+    }
+
+    public static function backendSupportsAmount($amount) {
+        return function($backend) use ($amount) { return !empty($backend->amount) && $backend->amount['min']<=$amount && $backend->amount['max']>=$amount; };
+    }
+
+
+    /**
+     * Combines boolean filters.
+     *    
+     * @return function
+     */
+    public static function combineFilters($filters) {
+        return function($a) use ($filters) {
+            $res = true;
+            foreach ($filters as $filter) $res &= $filter($a);
+            return $res;
+        };
+    }
+
+    /**
      * (non-PHPdoc)
      *
      * @see OmiseApiResource::g_reload()

--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -82,9 +82,7 @@ class OmiseCapabilities extends OmiseApiResource
      */
     private static function getUrl()
     {
-        ////// return OMISE_API_URL.self::ENDPOINT;
-        return 'https://api-staging.omise.co/'.self::ENDPOINT;
-        // return "http://www.mocky.io/v2/5bd695e33500004900fd7bf4";
+        return OMISE_API_URL.self::ENDPOINT;
     }
 
     /**

--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -47,7 +47,11 @@ class OmiseCapabilities extends OmiseApiResource
     }
 
     public static function backendSupportsAmount($amount) {
-        return function($backend) use ($amount) { return !empty($backend->amount) && $backend->amount['min']<=$amount && $backend->amount['max']>=$amount; };
+        return function($backend) use ($amount) {
+            if (!empty($backend->amount['min']) && $backend->amount['min'] > $amount) return false;
+            if (!empty($backend->amount['max']) && $backend->amount['max'] < $amount) return false;
+            return true;
+        };
     }
 
 

--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -74,7 +74,7 @@ class OmiseCapabilities extends OmiseApiResource
         return function($backend) use ($amount, $defMin, $defMax) {
             $min = empty($backend->amount['min']) ? $defMin : $backend->amount['min'];
             $max = empty($backend->amount['max']) ? $defMax : $backend->amount['max'];
-            return $amount < $min || $amount > $max;
+            return $amount >= $min && $amount <= $max;
         };
     }
 

--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -58,9 +58,8 @@ class OmiseCapabilities extends OmiseApiResource
      */
     public static function combineFilters($filters) {
         return function($a) use ($filters) {
-            $res = true;
-            foreach ($filters as $filter) $res &= $filter($a);
-            return $res;
+            foreach ($filters as $filter) if (!$filter($a)) return false;
+            return true;
         };
     }
 

--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -1,0 +1,51 @@
+<?php
+
+class OmiseCapabilities extends OmiseApiResource
+{
+    const ENDPOINT = 'capability';
+
+    /**
+     * Retrieves capabilities.
+     *
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseCapabilities
+     */
+    public static function retrieve($publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl(), $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        parent::g_reload(self::getUrl());
+    }
+
+    /**
+     * @return string
+     */
+    private static function getUrl()
+    {
+        ////// return OMISE_API_URL.self::ENDPOINT;
+        return "http://www.mocky.io/v2/5bd695e33500004900fd7bf4";
+    }
+
+    /**
+     * Checks if response from API was valid.
+     *
+     * @param  array  $array  - decoded JSON response
+     * 
+     * @return boolean
+     */
+    protected function isValidAPIResponse($array)
+    {
+        return count($array);
+    }
+
+}

--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -34,7 +34,7 @@ class OmiseCapabilities extends OmiseApiResource
             }
         );
         $res = array_map(function($a) { return (object)reset($a);}, $res);
-        return $filter ? array_filter($res, $filter) : $res;
+        return !empty($filter) ? array_filter($res, $filter) : $res;
     }
 
 
@@ -83,7 +83,8 @@ class OmiseCapabilities extends OmiseApiResource
     private static function getUrl()
     {
         ////// return OMISE_API_URL.self::ENDPOINT;
-        return "http://www.mocky.io/v2/5bd695e33500004900fd7bf4";
+        return 'https://api-staging.omise.co/'.self::ENDPOINT;
+        // return "http://www.mocky.io/v2/5bd695e33500004900fd7bf4";
     }
 
     /**
@@ -96,6 +97,16 @@ class OmiseCapabilities extends OmiseApiResource
     protected function isValidAPIResponse($array)
     {
         return count($array);
+    }
+
+    /**
+     * Returns the public key.
+     *
+     * @return string
+     */
+    protected function getResourceKey()
+    {
+        return $this->_publickey;
     }
 
 }

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -144,7 +144,7 @@ class OmiseApiResource extends OmiseObject
         $array = json_decode($result, true);
 
         // If response is invalid or not a JSON.
-        if (count($array) === 0 || ! isset($array['object'])) {
+        if (!$this->isValidAPIResponse($array)) {
             throw new Exception('Unknown error. (Bad Response)');
         }
 
@@ -154,6 +154,18 @@ class OmiseApiResource extends OmiseObject
         }
 
         return $array;
+    }
+
+    /**
+     * Checks if response from API was valid.
+     *
+     * @param  array  $array  - decoded JSON response
+     * 
+     * @return boolean
+     */
+    protected function isValidAPIResponse($array)
+    {
+        return count($array) && isset($array['object']);
     }
 
     /**

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -149,7 +149,7 @@ class OmiseApiResource extends OmiseObject
         }
 
         // If response is an error object.
-        if ($array['object'] === 'error') {
+        if (!empty($array['object']) && $array['object'] === 'error') {
             throw OmiseException::getInstance($array);
         }
 


### PR DESCRIPTION
Initial support for capability API. Allows us to:
- Retrieve Capabilities data
- Query said data for info on available payment backends

Sample code:
```PHP
<?php

require_once 'lib/Omise.php';

define('OMISE_PUBLIC_KEY', 'pkey_test_blahblahblahblahbla');
define('OMISE_SECRET_KEY', 'skey_test_blahblahblahblahbla');



$capabilities = OmiseCapabilities::retrieve();


$instalmentBackends = $capabilities->getBackends(
	$capabilities->backendTypeIs('installment'),
	$capabilities->backendSupportsCurrency('THB'),
	$capabilities->backendSupportsChargeAmount(1000)
);


foreach ($instalmentBackends as $backend) {
	print_r($backend);
}

```