### PR TITLE
Add PHP Code Sniffer 3.x to the composer package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "php": ">=5.3.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.4.*"
+        "phpunit/phpunit": "4.4.*",
+        "squizlabs/php_codesniffer": "3.*"
     },
     "autoload": {
         "classmap": ["lib/omise/"]

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
+    <file>lib</file>
+    <file>tests</file>
+
+    <arg name="basepath" value="." />
+    <arg name="colors" />
+    <arg name="parallel" value="75" />
+    <arg value="np" />
+
+    <rule ref="PSR2">
+        <exclude name="PSR1.Classes.ClassDeclaration.MissingNamespace" />
+        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps" />
+    </rule>
+</ruleset>


### PR DESCRIPTION
> ⚠️ This pull request requires #87 to be merged first.

### 1. Objective
Omise-PHP recently has been developed using the PSR Code Standards as a based code-style guide, but still, many parts of the code are still left untouched.

This pull request is introducing an automate tool to scan through the whole project finding those left-over code so the developers can provide a better code maintenance and code consistency.

> **Note 1:** This pull request is not to introduce the change of those code styling but to introduce a tool.
>
> **Note 2:** As in the ruleset, there are 2 excluded rules. It is because originally the project hadn't been developed based on those 2 rules, and it would require a lot of changes on both core code of the library and the interface (like, namespace).
> So I decided to pull it off for now, it will be applied back again at Omise-PHP v3.0.
>
> **Note 3:** This PHP Code Sniffer can be introduced as a one step for the CircleCI to automate it, but as from the note [1], I think it would be a good idea to provide a code-cleaning first, before add this `phpcs` into the CircleCI step. 

### To install and test the script
You can install the package via **Composer** by executing the following code: `composer update`.
Then, run `./vendor/bin/phpcs` to scan the project.
<img width="1550" alt="screen shot 2561-11-10 at 15 13 08" src="https://user-images.githubusercontent.com/2154669/48299127-25fc0e00-e4fb-11e8-9b1c-b2fa9b915586.png">