### PR TITLE
OmiseCardList, relocate the card-fetching logic back to its parent class (OmiseCustomer).

### DIFF
--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -12,16 +12,11 @@ class OmiseCardList extends OmiseApiResource
      * @param string $publickey
      * @param string $secretkey
      */
-    public function __construct($cards, $customerID, $options = array(), $publickey = null, $secretkey = null)
+    public function __construct($cards, $customerID, $publickey = null, $secretkey = null)
     {
         parent::__construct($publickey, $secretkey);
         $this->_customerID = $customerID;
-
-        if (is_array($options) && ! empty($options)) {
-            parent::g_reload($this->getUrl('?'.http_build_query($options)));
-        } else {
-            $this->refresh($cards);
-        }
+        $this->refresh($cards);
     }
   
     /**

--- a/lib/omise/OmiseCustomer.php
+++ b/lib/omise/OmiseCustomer.php
@@ -99,9 +99,13 @@ class OmiseCustomer extends OmiseApiResource
      */
     public function cards($options = array())
     {
-        if ($this['object'] === 'customer') {
-            return new OmiseCardList($this['cards'], $this['id'], $options, $this->_publickey, $this->_secretkey);
+        if (is_array($options) && ! empty($options)) {
+            $cards = parent::execute(self::getUrl($this['id']) . '/cards?' . http_build_query($options), parent::REQUEST_GET, parent::getResourceKey());
+        } else {
+            $cards = $this['cards'];
         }
+
+        return new OmiseCardList($cards, $this['id'], $this->_publickey, $this->_secretkey);
     }
   
     /**


### PR DESCRIPTION
### Objective

While implementing a new approach to generate an API url I found out that fetching a new data within OmiseCardList class will make the code losing benefit of its parent class' property.

For example, we cannot refer to `OmiseCustomer['id']` or `OmiseCustomer['location']` if we fetch the card information inside OmiseCardList.
```php
class OmiseCustomer extends OmiseApiResource
{
    ...
    /**
     * Gets a list of all cards belongs to this customer.
     *
     * @param  array $options
     *
     * @return OmiseCardList
     */
    public function cards($options = array())
    {
        // Fetch card list from $this['location'] . '/cards';
    }
}
```

### Quality Assurance
Make sure that the card list can still be fetched from `OmiseCustomer`.

```php
$customer = OmiseCustomer::retrieve('cust_test_5das2***');
$cards = $customer->cards();
``` 

or 
```php
$customer = OmiseCustomer::retrieve('cust_test_5das2***');
$cards = $customer->cards(['order' => 'reverse_chronological]);
```

Both should return

```php
OmiseCardList Object
(
    [_customerID:OmiseCardList:private] => cust_test_5das2***
    [OMISE_CONNECTTIMEOUT:OmiseApiResource:private] => 30
    [OMISE_TIMEOUT:OmiseApiResource:private] => 60
    [_values:protected] => Array
        (
            // data
        )
    [_secretkey:protected] => skey_test_5bs***
    [_publickey:protected] => pkey_test_5bs***
)