### PR TITLE
Be able to filter when retrieving a Refund List from a Charge object.

### DIFF
--- a/lib/omise/OmiseCharge.php
+++ b/lib/omise/OmiseCharge.php
@@ -115,11 +115,15 @@ class OmiseCharge extends OmiseApiResource
      *
      * @return OmiseRefundList
      */
-    public function refunds()
+    public function refunds($options = array())
     {
-        $result = parent::execute(self::getUrl($this['id']).'/refunds', parent::REQUEST_GET, parent::getResourceKey());
+        if (is_array($options) && ! empty($options)) {
+            $refunds = parent::execute(self::getUrl($this['id']) . '/refunds?' . http_build_query($options), parent::REQUEST_GET, parent::getResourceKey());
+        } else {
+            $refunds = $this['refunds'];
+        }
 
-        return new OmiseRefundList($result, $this['id'], $this->_publickey, $this->_secretkey);
+        return new OmiseRefundList($refunds, $this['id'], $this->_publickey, $this->_secretkey);
     }
 
     /**


### PR DESCRIPTION
### Objective

There is a case that user wants to retrieve a Refund List in `reverse_chronological` order from a Charge Object.

With the current code, it is impossible to achieve the above use case as there is no way to pass those filters when retrieving Refund List object from a Charge object.
```php
$charge  = OmiseCharge::retrieve('chrg_test_xx');
$refunds = $charge->refunds();
```

### Quality Assurance

Execute the following 2 code
```php
$charge  = OmiseCharge::retrieve('chrg_test_xx');
$refunds = $charge->refunds();
```
and
```php
$charge  = OmiseCharge::retrieve('chrg_test_xx');
$refunds = $charge->refunds(['limit' => 3, 'order' => 'reverse_chronological']);
```

The second code should alter the result of the Refund List object.

<img width="1552" alt="screen_shot_2561-11-20_at_10_22_28" src="https://user-images.githubusercontent.com/2154669/48749847-3e181e00-ecaf-11e8-9949-92c79ff010a8.png">

### Additional Notes
In the previous, the following code will always fetch a new Refund List object from Omise API.
```php
$charge  = OmiseCharge::retrieve('chrg_test_xx');
$refunds = $charge->refunds();
```

But after the change, if there is no `filter` option passing through the `$charge->refunds();` method the code will instead, assign `$this['refunds']` to `OmiseRefundList` object (no request to Omise API).