### PR TITLE
Refundable within charge class

### DIFF
--- a/lib/omise/OmiseCharge.php
+++ b/lib/omise/OmiseCharge.php
@@ -98,6 +98,17 @@ class OmiseCharge extends OmiseApiResource
     }
 
     /**
+     * Refund a charge.
+     *
+     * @return OmiseRefund
+     */
+    public function refund($params)
+    {
+        $result = parent::execute(self::getUrl($this['id']) . '/refunds', parent::REQUEST_POST, parent::getResourceKey(), $params);
+        return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
+    }
+
+    /**
      * Reverses a charge.
      *
      * @return OmiseCharge

--- a/tests/omise/ChargeTest.php
+++ b/tests/omise/ChargeTest.php
@@ -13,6 +13,7 @@ class ChargeTest extends TestConfig
         $this->assertTrue(method_exists('OmiseCharge', 'update'));
         $this->assertTrue(method_exists('OmiseCharge', 'capture'));
         $this->assertTrue(method_exists('OmiseCharge', 'reverse'));
+        $this->assertTrue(method_exists('OmiseCharge', 'refund'));
         $this->assertTrue(method_exists('OmiseCharge', 'refunds'));
         $this->assertTrue(method_exists('OmiseCharge', 'getUrl'));
     }
@@ -85,6 +86,19 @@ class ChargeTest extends TestConfig
         $this->assertArrayHasKey('object', $charge);
         $this->assertEquals('charge', $charge['object']);
         $this->assertTrue($charge['captured']);
+    }
+
+    /**
+     * @test
+     */
+    public function refund()
+    {
+        $charge = OmiseCharge::retrieve('chrg_test_4zmrjgxdh4ycj2qncoj');
+        $refund = $charge->refund(array('amount' => 10000));
+
+        $this->assertArrayHasKey('object', $refund);
+        $this->assertEquals('refund', $refund['object']);
+        $this->assertEquals(10000, $refund['amount']);
     }
 
     /**


### PR DESCRIPTION
### Objective

This is low priority but to enhance the code interface of refunding a charge.

**Before:**
```php
$charge = OmiseCharge::retrieve('chrg_test_xxx');
$refund = $charge->refunds()->create(array('amount' => 100));
```

**After:**
```php
$charge = OmiseCharge::retrieve('chrg_test_xxx');
$refund = $charge->refund(array('amount' => 100));
```


### Quality Assurance

Create a new refund using the following code

```php
$charge = OmiseCharge::retrieve('chrg_test_xxx');
$refund = $charge->refund(array('amount' => 100));
```

Should give you the same result as below.

<img width="1440" alt="screen shot 2561-11-20 at 10 57 48" src="https://user-images.githubusercontent.com/2154669/48750718-2e9ad400-ecb3-11e8-8d98-bbf8130ae20b.png">

_Note: at the screenshot above, I did printed `$charge->refunds(['order' => 'reverse_chronological', 'limit' => 1]);` to make sure that the refund has been created and added back to RefundList object properly._