### PR TITLE
Fix bug "authentication failed" when executing OmiseTransfer::search()

### DIFF
--- a/lib/omise/OmiseTransfer.php
+++ b/lib/omise/OmiseTransfer.php
@@ -27,7 +27,7 @@ class OmiseTransfer extends OmiseApiResource
      *
      * @return OmiseSearch
      */
-    public static function search($query = '', $publickey = '', $secretkey = '')
+    public static function search($query = '', $publickey = null, $secretkey = null)
     {
         return OmiseSearch::scope('transfer', $publickey, $secretkey)->query($query);
     }


### PR DESCRIPTION
### Objective

To fix a bug of cannot use `OmiseTransfer::search()` without passing public key and secret key.
The below code will raise an authentication error
```php
$transfers = OmiseTransfer::search();
```

<img width="709" alt="screen shot 2561-11-21 at 09 54 27" src="https://user-images.githubusercontent.com/2154669/48816111-797c2080-ed73-11e8-9e69-ec5733d25cfb.png">

### Cause

If we take a look at the original below code

```php
class OmiseTransfer extends OmiseApiResource
{
    ...

    public static function search($query = '', $publickey = '', $secretkey = '')
    {
        return OmiseSearch::scope('transfer', $publickey, $secretkey)->query($query);
    }
}
```

It is because `publickey` and `secretkey` are passed to the `OmiseSearch::scope` with an `empty string` by default, which, OmiseSearch class passes those 2 keys to the OmiseObject's constructor.

But at the OmiseObject, constructor method, there is a condition to check that if value is `not null`, then assign it to its property
```php
class OmiseObject
{
    ...
    protected function __construct($publickey = null, $secretkey = null)
    {
        if ($publickey !== null) {
            $this->_publickey = $publickey;
        } else {
            $this->_publickey = OMISE_PUBLIC_KEY;
        }

        if ($secretkey !== null) {
            $this->_secretkey = $secretkey;
        } else {
            $this->_secretkey = OMISE_SECRET_KEY;
        }
}
```

So executing `OmiseTransfer::search();` makes the pre-configured public key and secret key wiped out.

### Quality Assurance

Execute the below code again and the problem should be fixed.

```php
$transfers = OmiseTransfer::search();
```

<img width="717" alt="screen shot 2561-11-21 at 10 04 10" src="https://user-images.githubusercontent.com/2154669/48816447-d1ffed80-ed74-11e8-9e85-139c12fb7697.png">
