### PR TITLE
Separating API Requesting concern out from OmiseApiResource to a proper dedicated class.

### DIFF
--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -1,5 +1,6 @@
 <?php
 // Cores and utilities.
+require_once dirname(__FILE__).'/omise/ApiRequestor.php';
 require_once dirname(__FILE__).'/omise/res/obj/OmiseObject.php';
 require_once dirname(__FILE__).'/omise/res/OmiseApiResource.php';
 require_once dirname(__FILE__).'/omise/Http/Response/Handler.php';

--- a/lib/omise/ApiRequestor.php
+++ b/lib/omise/ApiRequestor.php
@@ -17,10 +17,12 @@ class ApiRequestor
      * Request methods
      * @var string
      */
-    const REQUEST_GET    = 'GET';
-    const REQUEST_POST   = 'POST';
-    const REQUEST_PATCH  = 'PATCH';
-    const REQUEST_DELETE = 'DELETE';
+    const REQUEST_GET     = 'GET';
+    const REQUEST_POST    = 'POST';
+    const REQUEST_PATCH   = 'PATCH';
+    const REQUEST_DELETE  = 'DELETE';
+    const REQUEST_METHODS = array(self::REQUEST_GET, self::REQUEST_POST, self::REQUEST_PATCH, self::REQUEST_DELETE);
+
 
     /**
      * Timeout setting
@@ -30,43 +32,18 @@ class ApiRequestor
     private $OMISE_TIMEOUT        = 60;
 
     /**
-     * @param string $url
-     * @param string $key
-     * @param array  $params
+     * @param string $arguments[0]  An API endpoint
+     * @param string $arguments[1]  Omise secret key
+     * @param array  $arguments[2]  Parameters
      */
-    public function get($url, $key, $params = null)
+    public function __call($name, $arguments)
     {
-        return $this->request($url, self::REQUEST_GET, $key, $params);
-    }
+        $requestMethodName = strtoupper($name);
+        if (! in_array($requestMethodName, self::REQUEST_METHODS)) {
+            throw new Exception('Request method "' . $requestMethodName . '" not supported.', 1);
+        }
 
-    /**
-     * @param string $url
-     * @param string $key
-     * @param array  $params
-     */
-    public function post($url, $key, $params = null)
-    {
-        return $this->request($url, self::REQUEST_POST, $key, $params);
-    }
-
-    /**
-     * @param string $url
-     * @param string $key
-     * @param array  $params
-     */
-    public function patch($url, $key, $params = null)
-    {
-        return $this->request($url, self::REQUEST_PATCH, $key, $params);
-    }
-
-    /**
-     * @param string $url
-     * @param string $key
-     * @param array  $params
-     */
-    public function delete($url, $key, $params = null)
-    {
-        return $this->request($url, self::REQUEST_DELETE, $key, $params);
+        return $this->request($arguments[0], $requestMethodName, $arguments[1], count($arguments) > 2 ? $arguments[2] : null);
     }
 
     /**

--- a/lib/omise/ApiRequestor.php
+++ b/lib/omise/ApiRequestor.php
@@ -1,0 +1,222 @@
+<?php
+namespace Omise;
+
+use Omise\Http\Response\Handler as ResponseHandler;
+use Exception;
+
+class ApiRequestor
+{
+    /**
+     * @var string
+     */
+    const OMISE_PHP_LIB_VERSION = '3.0.0-dev';
+    const OMISE_API_URL         = 'https://api.omise.co/';
+    const OMISE_VAULT_URL       = 'https://vault.omise.co/';
+
+    /**
+     * Request methods
+     * @var string
+     */
+    const REQUEST_GET    = 'GET';
+    const REQUEST_POST   = 'POST';
+    const REQUEST_PATCH  = 'PATCH';
+    const REQUEST_DELETE = 'DELETE';
+
+    /**
+     * Timeout setting
+     * @var int
+     */
+    private $OMISE_CONNECTTIMEOUT = 30;
+    private $OMISE_TIMEOUT        = 60;
+
+    /**
+     * @param string $url
+     * @param string $key
+     * @param array  $params
+     */
+    public function get($url, $key, $params = null)
+    {
+        return $this->request($url, self::REQUEST_GET, $key, $params);
+    }
+
+    /**
+     * @param string $url
+     * @param string $key
+     * @param array  $params
+     */
+    public function post($url, $key, $params = null)
+    {
+        return $this->request($url, self::REQUEST_POST, $key, $params);
+    }
+
+    /**
+     * @param string $url
+     * @param string $key
+     * @param array  $params
+     */
+    public function patch($url, $key, $params = null)
+    {
+        return $this->request($url, self::REQUEST_PATCH, $key, $params);
+    }
+
+    /**
+     * @param string $url
+     * @param string $key
+     * @param array  $params
+     */
+    public function delete($url, $key, $params = null)
+    {
+        return $this->request($url, self::REQUEST_DELETE, $key, $params);
+    }
+
+    /**
+     * @param string $url
+     * @param string $requestMethod
+     * @param string $key
+     * @param array  $params
+     */
+    public function request($url, $requestMethod, $key, $params = null)
+    {
+        // If this class is execute by phpunit > get test mode.
+        if (preg_match('/phpunit/', $_SERVER['SCRIPT_NAME'])) {
+            $result = $this->_executeTest($url, $requestMethod, $key, $params);
+        } else {
+            $result = $this->_executeCurl($url, $requestMethod, $key, $params);
+        }
+
+        $responseHandler = new ResponseHandler;
+        return $responseHandler->handle($result);
+    }
+
+    /**
+     * @param  string $url
+     * @param  string $requestMethod
+     * @param  array  $params
+     *
+     * @throws OmiseException
+     *
+     * @return string
+     */
+    private function _executeCurl($url, $requestMethod, $key, $params = null)
+    {
+        $ch = curl_init($url);
+
+        curl_setopt_array($ch, $this->genOptions($requestMethod, $key.':', $params));
+
+        // Make a request or thrown an exception.
+        if (($result = curl_exec($ch)) === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+
+            throw new Exception($error);
+        }
+
+        // Close.
+        curl_close($ch);
+
+        return $result;
+    }
+
+    /**
+     * @param  string $url
+     * @param  string $requestMethod
+     * @param  array  $params
+     *
+     * @throws OmiseException
+     *
+     * @return string
+     */
+    private function _executeTest($url, $requestMethod, $key, $params = null)
+    {
+        // Extract only hostname and URL path without trailing slash.
+        $parsed      = parse_url($url);
+        $requestUrl = $parsed['host'] . rtrim($parsed['path'], '/');
+
+        // Convert query string into filename friendly format.
+        if (!empty($parsed['query'])) {
+            $query      = base64_encode($parsed['query']);
+            $query      = str_replace(array('+', '/', '='), array('-', '_', ''), $query);
+            $requestUrl = $requestUrl . '-' . $query;
+        }
+
+        // Finally.
+        $requestUrl = dirname(__FILE__) . '/../../tests/fixtures/' . $requestUrl . '-' . strtolower($requestMethod) . '.json';
+
+        // Make a request from Curl if json file was not exists.
+        if (!file_exists($requestUrl)) {
+            // Get a directory that's file should contain.
+            $request_dir = explode('/', $requestUrl);
+            unset($request_dir[count($request_dir) - 1]);
+            $request_dir = implode('/', $request_dir);
+
+            // Create directory if it not exists.
+            if (! file_exists($request_dir)) {
+                mkdir($request_dir, 0777, true);
+            }
+
+            $result = $this->_executeCurl($url, $requestMethod, $key, $params);
+
+            $f = fopen($requestUrl, 'w');
+            if ($f) {
+                fwrite($f, $result);
+                fclose($f);
+            }
+        } else {
+            // Or get response from json file.
+            $result = file_get_contents($requestUrl);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Creates an option for php-curl from the given request method and parameters in an associative array.
+     *
+     * @param  string $requestMethod
+     * @param  array  $params
+     *
+     * @return array
+     */
+    private function genOptions($requestMethod, $userpassword, $params)
+    {
+        $certificateFileLocation = dirname(__FILE__) . '/../../data/ca_certificates.pem';
+        $userAgent               = 'OmisePHP/' . self::OMISE_PHP_LIB_VERSION . ' PHP/' . phpversion();
+
+        $options = array(
+            CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,       // Set the HTTP version to 1.1.
+            CURLOPT_CUSTOMREQUEST  => $requestMethod,              // Set the request method.
+            CURLOPT_RETURNTRANSFER => true,                        // Make php-curl returns the data as string.
+            CURLOPT_HEADER         => false,                       // Do not include the header in the output.
+            CURLINFO_HEADER_OUT    => true,                        // Track the header request string and set the referer on redirect.
+            CURLOPT_AUTOREFERER    => true,
+            CURLOPT_TIMEOUT        => $this->OMISE_TIMEOUT,        // Time before the request is aborted.
+            CURLOPT_CONNECTTIMEOUT => $this->OMISE_CONNECTTIMEOUT, // Time before the request is aborted when attempting to connect.
+            CURLOPT_USERPWD        => $userpassword,               // Authentication.
+            CURLOPT_CAINFO         => $certificateFileLocation     // CA bundle.
+        );
+
+        // Config Omise API Version
+        if (defined('OMISE_API_VERSION')) {
+            $options += array(CURLOPT_HTTPHEADER => array('Omise-Version: ' . OMISE_API_VERSION));
+
+            $userAgent .= ' OmiseAPI/' . OMISE_API_VERSION;
+        }
+
+        // Config UserAgent
+        if (defined('OMISE_USER_AGENT_SUFFIX')) {
+            $userAgent .= $userAgent . ' ' . OMISE_USER_AGENT_SUFFIX;
+        }
+
+        $options += array(CURLOPT_USERAGENT => $userAgent);
+
+        // Also merge POST parameters with the option.
+        if (is_array($params) && count($params) > 0) {
+            $httpQuery = http_build_query($params);
+            $httpQuery = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $httpQuery);
+
+            $options += array(CURLOPT_POSTFIELDS => $httpQuery);
+        }
+
+        return $options;
+    }
+}

--- a/lib/omise/OmiseAccount.php
+++ b/lib/omise/OmiseAccount.php
@@ -34,6 +34,6 @@ class OmiseAccount extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL . self::ENDPOINT . '/' . $id;
     }
 }

--- a/lib/omise/OmiseBalance.php
+++ b/lib/omise/OmiseBalance.php
@@ -34,6 +34,6 @@ class OmiseBalance extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL . self::ENDPOINT . '/' . $id;
     }
 }

--- a/lib/omise/OmiseCard.php
+++ b/lib/omise/OmiseCard.php
@@ -69,6 +69,6 @@ class OmiseCard extends OmiseApiResource
      */
     private function getUrl($cardID = '')
     {
-        return OMISE_API_URL.OmiseCustomer::ENDPOINT.'/'.$this->_customerID.'/'.self::ENDPOINT.'/'.$cardID;
+        return \Omise\ApiRequestor::OMISE_API_URL.OmiseCustomer::ENDPOINT.'/'.$this->_customerID.'/'.self::ENDPOINT.'/'.$cardID;
     }
 }

--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -28,7 +28,7 @@ class OmiseCardList extends OmiseApiResource
      */
     public function retrieve($id)
     {
-        $result = parent::execute($this->getUrl($id), parent::REQUEST_GET, self::getResourceKey());
+        $result = $this->apiRequestor->get($this->getUrl($id), self::getResourceKey());
 
         return new OmiseCard($result, $this->_customerID, $this->_publickey, $this->_secretkey);
     }
@@ -41,6 +41,6 @@ class OmiseCardList extends OmiseApiResource
      */
     private function getUrl($id = '')
     {
-        return OMISE_API_URL.'customers/'.$this->_customerID.'/'.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.'customers/'.$this->_customerID.'/'.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/OmiseCharge.php
+++ b/lib/omise/OmiseCharge.php
@@ -91,7 +91,7 @@ class OmiseCharge extends OmiseApiResource
      */
     public function capture()
     {
-        $result = parent::execute(self::getUrl($this['id']).'/capture', parent::REQUEST_POST, parent::getResourceKey());
+        $result = $this->apiRequestor->post(self::getUrl($this['id']).'/capture', parent::getResourceKey());
         $this->refresh($result);
 
         return $this;
@@ -104,7 +104,7 @@ class OmiseCharge extends OmiseApiResource
      */
     public function refund($params)
     {
-        $result = parent::execute(self::getUrl($this['id']) . '/refunds', parent::REQUEST_POST, parent::getResourceKey(), $params);
+        $result = $this->apiRequestor->post(self::getUrl($this['id']) . '/refunds', parent::getResourceKey(), $params);
         return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
     }
 
@@ -115,7 +115,7 @@ class OmiseCharge extends OmiseApiResource
      */
     public function reverse()
     {
-        $result = parent::execute(self::getUrl($this['id']).'/reverse', parent::REQUEST_POST, parent::getResourceKey());
+        $result = $this->apiRequestor->post(self::getUrl($this['id']).'/reverse', parent::getResourceKey());
         $this->refresh($result);
 
         return $this;
@@ -128,7 +128,7 @@ class OmiseCharge extends OmiseApiResource
      */
     public function refunds()
     {
-        $result = parent::execute(self::getUrl($this['id']).'/refunds', parent::REQUEST_GET, parent::getResourceKey());
+        $result = $this->apiRequestor->get(self::getUrl($this['id']).'/refunds', parent::getResourceKey());
 
         return new OmiseRefundList($result, $this['id'], $this->_publickey, $this->_secretkey);
     }
@@ -158,6 +158,6 @@ class OmiseCharge extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/OmiseCustomer.php
+++ b/lib/omise/OmiseCustomer.php
@@ -100,7 +100,7 @@ class OmiseCustomer extends OmiseApiResource
     public function cards($options = array())
     {
         if (is_array($options) && ! empty($options)) {
-            $cards = parent::execute(self::getUrl($this['id']) . '/cards?' . http_build_query($options), parent::REQUEST_GET, parent::getResourceKey());
+            $cards = $this->apiRequestor->get(self::getUrl($this['id']) . '/cards?' . http_build_query($options), parent::getResourceKey());
         } else {
             $cards = $this['cards'];
         }
@@ -145,6 +145,6 @@ class OmiseCustomer extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/OmiseDispute.php
+++ b/lib/omise/OmiseDispute.php
@@ -65,6 +65,6 @@ class OmiseDispute extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/OmiseEvent.php
+++ b/lib/omise/OmiseEvent.php
@@ -41,6 +41,6 @@ class OmiseEvent extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/OmiseForex.php
+++ b/lib/omise/OmiseForex.php
@@ -33,6 +33,6 @@ class OmiseForex extends OmiseApiResource
      */
     private static function getUrl($currency = '')
     {
-        return OMISE_API_URL . self::ENDPOINT . '/' . $currency;
+        return \Omise\ApiRequestor::OMISE_API_URL . self::ENDPOINT . '/' . $currency;
     }
 }

--- a/lib/omise/OmiseLink.php
+++ b/lib/omise/OmiseLink.php
@@ -67,6 +67,6 @@ class OmiseLink extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/OmiseOccurrence.php
+++ b/lib/omise/OmiseOccurrence.php
@@ -30,6 +30,6 @@ class OmiseOccurrence extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT . '/' . $id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT . '/' . $id;
     }
 }

--- a/lib/omise/OmiseRecipient.php
+++ b/lib/omise/OmiseRecipient.php
@@ -115,6 +115,6 @@ class OmiseRecipient extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/OmiseRefundList.php
+++ b/lib/omise/OmiseRefundList.php
@@ -26,7 +26,7 @@ class OmiseRefundList extends OmiseApiResource
      */
     public function create($params)
     {
-        $result = parent::execute($this->getUrl(), parent::REQUEST_POST, self::getResourceKey(), $params);
+        $result = $this->apiRequestor->post($this->getUrl(), self::getResourceKey(), $params);
 
         return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
     }
@@ -38,7 +38,7 @@ class OmiseRefundList extends OmiseApiResource
      */
     public function retrieve($id)
     {
-        $result = parent::execute($this->getUrl($id), parent::REQUEST_GET, self::getResourceKey());
+        $result = $this->apiRequestor->get($this->getUrl($id), self::getResourceKey());
 
         return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
     }
@@ -50,6 +50,6 @@ class OmiseRefundList extends OmiseApiResource
      */
     private function getUrl($id = '')
     {
-        return OMISE_API_URL.'charges/'.$this->_chargeID.'/'.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.'charges/'.$this->_chargeID.'/'.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/OmiseSchedule.php
+++ b/lib/omise/OmiseSchedule.php
@@ -85,6 +85,6 @@ class OmiseSchedule extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT . '/' . $id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT . '/' . $id;
     }
 }

--- a/lib/omise/OmiseSearch.php
+++ b/lib/omise/OmiseSearch.php
@@ -186,7 +186,7 @@ class OmiseSearch extends OmiseApiResource
     private function getUrl()
     {
         $querystring = http_build_query($this->attributes);
-        return OMISE_API_URL.self::ENDPOINT.'/?'.$querystring;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT.'/?'.$querystring;
     }
 
     // Override methods of ArrayAccess

--- a/lib/omise/OmiseSource.php
+++ b/lib/omise/OmiseSource.php
@@ -23,6 +23,6 @@ class OmiseSource extends OmiseApiResource
      */
     private static function getUrl()
     {
-        return OMISE_API_URL.self::ENDPOINT;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT;
     }
 }

--- a/lib/omise/OmiseToken.php
+++ b/lib/omise/OmiseToken.php
@@ -52,6 +52,6 @@ class OmiseToken extends OmiseVaultResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_VAULT_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_VAULT_URL . self::ENDPOINT . '/' . $id;
     }
 }

--- a/lib/omise/OmiseTransaction.php
+++ b/lib/omise/OmiseTransaction.php
@@ -39,6 +39,6 @@ class OmiseTransaction extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/OmiseTransfer.php
+++ b/lib/omise/OmiseTransfer.php
@@ -137,6 +137,6 @@ class OmiseTransfer extends OmiseApiResource
      */
     private static function getUrl($id = '')
     {
-        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+        return \Omise\ApiRequestor::OMISE_API_URL.self::ENDPOINT.'/'.$id;
     }
 }

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -1,20 +1,20 @@
 <?php
 
-define('OMISE_PHP_LIB_VERSION', '3.0.0-dev');
-define('OMISE_API_URL', 'https://api.omise.co/');
-define('OMISE_VAULT_URL', 'https://vault.omise.co/');
+use Omise\ApiRequestor;
 
 class OmiseApiResource extends OmiseObject
 {
-    // Request methods
-    const REQUEST_GET = 'GET';
-    const REQUEST_POST = 'POST';
-    const REQUEST_DELETE = 'DELETE';
-    const REQUEST_PATCH = 'PATCH';
+    public $apiRequestor;
 
-    // Timeout settings
-    private $OMISE_CONNECTTIMEOUT = 30;
-    private $OMISE_TIMEOUT = 60;
+    /**
+     * @param string $publickey
+     * @param string $secretkey
+     */
+    protected function __construct($publickey = null, $secretkey = null)
+    {
+        parent::__construct($publickey, $secretkey);
+        $this->apiRequestor = new ApiRequestor;
+    }
 
     /**
      * Returns an instance of the class given in $clazz or raise an error.
@@ -50,7 +50,7 @@ class OmiseApiResource extends OmiseObject
     protected static function g_retrieve($clazz, $url, $publickey = null, $secretkey = null)
     {
         $resource = call_user_func(array($clazz, 'getInstance'), $clazz, $publickey, $secretkey);
-        $result   = $resource->execute($url, self::REQUEST_GET, $resource->getResourceKey());
+        $result   = $resource->apiRequestor->get($url, $resource->getResourceKey());
         $resource->refresh($result);
 
         return $resource;
@@ -72,7 +72,7 @@ class OmiseApiResource extends OmiseObject
     protected static function g_create($clazz, $url, $params, $publickey = null, $secretkey = null)
     {
         $resource = call_user_func(array($clazz, 'getInstance'), $clazz, $publickey, $secretkey);
-        $result   = $resource->execute($url, self::REQUEST_POST, $resource->getResourceKey(), $params);
+        $result   = $resource->apiRequestor->post($url, $resource->getResourceKey(), $params);
         $resource->refresh($result);
 
         return $resource;
@@ -88,7 +88,7 @@ class OmiseApiResource extends OmiseObject
      */
     protected function g_update($url, $params)
     {
-        $result = $this->execute($url, self::REQUEST_PATCH, $this->getResourceKey(), $params);
+        $result = $this->apiRequestor->patch($url, $this->getResourceKey(), $params);
         $this->refresh($result);
     }
 
@@ -103,7 +103,7 @@ class OmiseApiResource extends OmiseObject
      */
     protected function g_destroy($url)
     {
-        $result = $this->execute($url, self::REQUEST_DELETE, $this->getResourceKey());
+        $result = $this->apiRequestor->delete($url, $this->getResourceKey());
         $this->refresh($result, true);
     }
 
@@ -116,175 +116,8 @@ class OmiseApiResource extends OmiseObject
      */
     protected function g_reload($url)
     {
-        $result = $this->execute($url, self::REQUEST_GET, $this->getResourceKey());
+        $result = $this->apiRequestor->get($url, $this->getResourceKey());
         $this->refresh($result);
-    }
-
-    /**
-     * Makes a request and returns a decoded JSON data as an associative array.
-     *
-     * @param  string $url
-     * @param  string $requestMethod
-     * @param  array  $params
-     *
-     * @throws OmiseException
-     *
-     * @return array
-     */
-    protected function execute($url, $requestMethod, $key, $params = null)
-    {
-        // If this class is execute by phpunit > get test mode.
-        if (preg_match('/phpunit/', $_SERVER['SCRIPT_NAME'])) {
-            $result = $this->_executeTest($url, $requestMethod, $key, $params);
-        } else {
-            $result = $this->_executeCurl($url, $requestMethod, $key, $params);
-        }
-
-        $responseHandler = new \Omise\Http\Response\Handler;
-        return $responseHandler->handle($result);
-    }
-
-    /**
-     * @param  string $url
-     * @param  string $requestMethod
-     * @param  array  $params
-     *
-     * @throws OmiseException
-     *
-     * @return string
-     */
-    private function _executeCurl($url, $requestMethod, $key, $params = null)
-    {
-        $ch = curl_init($url);
-
-        curl_setopt_array($ch, $this->genOptions($requestMethod, $key.':', $params));
-
-        // Make a request or thrown an exception.
-        if (($result = curl_exec($ch)) === false) {
-            $error = curl_error($ch);
-            curl_close($ch);
-
-            throw new Exception($error);
-        }
-
-        // Close.
-        curl_close($ch);
-
-        return $result;
-    }
-
-    /**
-     * @param  string $url
-     * @param  string $requestMethod
-     * @param  array  $params
-     *
-     * @throws OmiseException
-     *
-     * @return string
-     */
-    private function _executeTest($url, $requestMethod, $key, $params = null)
-    {
-        // Extract only hostname and URL path without trailing slash.
-        $parsed = parse_url($url);
-        $request_url = $parsed['host'] . rtrim($parsed['path'], '/');
-
-        // Convert query string into filename friendly format.
-        if (!empty($parsed['query'])) {
-            $query = base64_encode($parsed['query']);
-            $query = str_replace(array('+', '/', '='), array('-', '_', ''), $query);
-            $request_url = $request_url.'-'.$query;
-        }
-
-        // Finally.
-        $request_url = dirname(__FILE__).'/../../../tests/fixtures/'.$request_url.'-'.strtolower($requestMethod).'.json';
-
-        // Make a request from Curl if json file was not exists.
-        if (! file_exists($request_url)) {
-            // Get a directory that's file should contain.
-            $request_dir = explode('/', $request_url);
-            unset($request_dir[count($request_dir) - 1]);
-            $request_dir = implode('/', $request_dir);
-
-            // Create directory if it not exists.
-            if (! file_exists($request_dir)) {
-                mkdir($request_dir, 0777, true);
-            }
-
-            $result = $this->_executeCurl($url, $requestMethod, $key, $params);
-
-            $f = fopen($request_url, 'w');
-            if ($f) {
-                fwrite($f, $result);
-
-                fclose($f);
-            }
-        } else { // Or get response from json file.
-            $result = file_get_contents($request_url);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Creates an option for php-curl from the given request method and parameters in an associative array.
-     *
-     * @param  string $requestMethod
-     * @param  array  $params
-     *
-     * @return array
-     */
-    private function genOptions($requestMethod, $userpwd, $params)
-    {
-        $user_agent        = "OmisePHP/".OMISE_PHP_LIB_VERSION." PHP/".phpversion();
-        $omise_api_version = defined('OMISE_API_VERSION') ? OMISE_API_VERSION : null;
-
-        $options = array(
-            // Set the HTTP version to 1.1.
-            CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,
-            // Set the request method.
-            CURLOPT_CUSTOMREQUEST  => $requestMethod,
-            // Make php-curl returns the data as string.
-            CURLOPT_RETURNTRANSFER => true,
-            // Do not include the header in the output.
-            CURLOPT_HEADER         => false,
-            // Track the header request string and set the referer on redirect.
-            CURLINFO_HEADER_OUT    => true,
-            CURLOPT_AUTOREFERER    => true,
-            // Make HTTP error code above 400 an error.
-            // CURLOPT_FAILONERROR => true,
-            // Time before the request is aborted.
-            CURLOPT_TIMEOUT        => $this->OMISE_TIMEOUT,
-            // Time before the request is aborted when attempting to connect.
-            CURLOPT_CONNECTTIMEOUT => $this->OMISE_CONNECTTIMEOUT,
-            // Authentication.
-            CURLOPT_USERPWD        => $userpwd,
-            // CA bundle.
-            CURLOPT_CAINFO         => dirname(__FILE__).'/../../../data/ca_certificates.pem'
-        );
-
-        // Config Omise API Version
-        if ($omise_api_version) {
-            $options += array(CURLOPT_HTTPHEADER => array("Omise-Version: ".$omise_api_version));
-
-            $user_agent .= ' OmiseAPI/'.$omise_api_version;
-        }
-
-        // Config UserAgent
-        if (defined('OMISE_USER_AGENT_SUFFIX')) {
-            $options += array(CURLOPT_USERAGENT => $user_agent." ".OMISE_USER_AGENT_SUFFIX);
-        } else {
-            $options += array(CURLOPT_USERAGENT => $user_agent);
-        }
-
-        // Also merge POST parameters with the option.
-        if (is_array($params) && count($params) > 0) {
-            $http_query = http_build_query($params);
-            $http_query = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $http_query);
-
-            $options += array(CURLOPT_POSTFIELDS => $http_query);
-        }
-
-        return $options;
     }
 
     /**

--- a/tests/omise/ApiRequestorTest.php
+++ b/tests/omise/ApiRequestorTest.php
@@ -76,4 +76,14 @@ class ApiRequestorTest extends \TestConfig
         $this->assertSame($result['object'], 'customer');
         $this->assertTrue($result['deleted']);
     }
+
+    /**
+     * @test
+     * @expectedException        \Exception
+     * @expectedExceptionMessage Request method "GOT" not supported.
+     */
+    public function make_unsupported_method_request()
+    {
+        $this->apiRequestor->got('http://test', 'secretkey');
+    }
 }

--- a/tests/omise/ApiRequestorTest.php
+++ b/tests/omise/ApiRequestorTest.php
@@ -1,0 +1,79 @@
+<?php
+require_once dirname(__FILE__).'/TestConfig.php';
+
+class ApiRequestorTest extends \TestConfig
+{
+    /**
+     * @var \Omise\ApiRequestor
+     */
+    private $apiRequestor;
+
+    public function setUp()
+    {
+        $this->apiRequestor = new \Omise\ApiRequestor;
+    }
+
+    /**
+     * @test
+     */
+    public function make_get_request()
+    {
+        // This endpoint will be resolved to a json-mock file,
+        // test/fixtures/api.omise.co/account-get.json
+        $url = \Omise\ApiRequestor::OMISE_API_URL . 'account';
+
+        $result = $this->apiRequestor->get($url, 'secretkey');
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertSame($result['object'], 'account');
+        $this->assertSame($result['id'], 'acct_4yyvy93tmab34q2ywlo');
+    }
+
+    /**
+     * @test
+     */
+    public function make_post_request()
+    {
+        // This endpoint will be resolved to a json-mock file,
+        // test/fixtures/api.omise.co/charges-post.json
+        $url = \Omise\ApiRequestor::OMISE_API_URL . 'charges';
+
+        $result = $this->apiRequestor->post($url, 'secretkey', array('amount' => 100000));
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertSame($result['object'], 'charge');
+        $this->assertSame($result['id'], 'chrg_test_4zmrjgxdh4ycj2qncoj');
+    }
+
+    /**
+     * @test
+     */
+    public function make_patch_request()
+    {
+        // This endpoint will be resolved to a json-mock file,
+        // test/fixtures/api.omise.co/charges/chrg_test_4zmrjgxdh4ycj2qncoj-patch.json
+        $url = \Omise\ApiRequestor::OMISE_API_URL . 'charges/chrg_test_4zmrjgxdh4ycj2qncoj';
+
+        $result = $this->apiRequestor->patch($url, 'secretkey', array('description' => 'mock'));
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertSame($result['object'], 'charge');
+        $this->assertSame($result['id'], 'chrg_test_4zmrjgxdh4ycj2qncoj');
+    }
+
+    /**
+     * @test
+     */
+    public function make_delete_request()
+    {
+        // This endpoint will be resolved to a json-mock file,
+        // test/fixtures/api.omise.co/customers/cust_test_4zmrjg2hct06ybwobqc-delete.json
+        $url = \Omise\ApiRequestor::OMISE_API_URL . 'customers/cust_test_4zmrjg2hct06ybwobqc';
+
+        $result = $this->apiRequestor->delete($url, 'secretkey');
+
+        $this->assertArrayHasKey('id', $result);
+        $this->assertSame($result['object'], 'customer');
+        $this->assertTrue($result['deleted']);
+    }
+}


### PR DESCRIPTION
### Objective

By the current design of `OmiseApiResource` class makes the code hard to maintain (as all of API requestor & resource methods are being held in the same class) and unable to properly test those API requesting methods, such as `execute`, `_executeCurl`.

This pull request is aiming to separate and decouple the concern of API request out from `OmiseApiResource` to a proper dedicated class.

### Quality Assurance

I wrote scripts to test all of methods in every resource classes and tested executed almost every possibility cases and it worked fine.

<img width="1552" alt="screen shot 2561-11-26 at 16 30 03" src="https://user-images.githubusercontent.com/2154669/49005148-914f0c80-f198-11e8-9462-a155069c2a6c.png">

Can check the script at the following repository.
https://github.com/guzzilar/omise-php-examples