### PR TITLE
Officially dropping support of PHP v5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please pop onto our [community forum](https://forum.omise.co) or contact [suppor
 
 ## Requirements
 
-* PHP v5.3 and above.
+* PHP v5.4 and above.
 * Built-in [libcurl](http://php.net/manual/en/book.curl.php) support.
 
 > Note that, due to the PHP [END OF LIFE](http://php.net/supported-versions.php) cycle, we encourage you to run Omise-PHP library on a PHP version 5.6 or higher as there is no longer security support for any below 5.6 and that could cause you any security vulnerable issues in the future.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "forum": "https://forum.omise.co"
     },
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.4.*",


### PR DESCRIPTION
## IMPORTANT
Omise-PHP v2.11.0 and above will **NO LONGER SUPPORT** for `PHP v5.3 and below`.

However, we will still continue providing support in case of security & maintenance as a bugfix on Omise-PHP `v2.10.x`.
For anyone who is still using those legacy PHP versions, we do recommend to upgrade your PHP server to at least v5.6 (or v7.x if possible) as there is no more bugfix, patch, security support provided by PHP community (as those versions are in the End Of Life stage already).

See: http://php.net/eol.php and http://php.net/supported-versions.php