### PR TITLE
OmiseCapabilities: Correcting OMISE_API_URL path.

### DIFF
--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -169,7 +169,7 @@ class OmiseCapabilities extends OmiseApiResource
      */
     private static function getUrl()
     {
-        return OMISE_API_URL . self::ENDPOINT;
+        return \Omise\ApiRequestor::OMISE_API_URL . self::ENDPOINT;
     }
 
     /**


### PR DESCRIPTION
### 1. Objective
`Omise-PHP v3.0.0-dev` is now merged with the latest Omise-PHP `v2.11.0`, which in Omise-PHP v2.11.0, it still uses `OMISE_API_URL` constant while it has been removed already in the v3.0.0-dev.

This pull request is to correct `OMISE_API_URL`'s path.