### PR TITLE
✨ Hello v2.11.1 ✨

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+### [v2.11.1 _(Jan 16, 2019)_](https://github.com/omise/omise-php/releases/tag/v2.11.1)
+
+#### 👾 Bug Fixes
+
+- Fixes issue with use of array constant (mandated PHP 5.6+). (PR [#106](https://github.com/omise/omise-php/pull/106))
+
+---
+
 ### [v2.11.0 _(Jan 9, 2019)_](https://github.com/omise/omise-php/releases/tag/v2.11.0)
 
 #### ✨ Highlights

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can install the library via [Composer](https://getcomposer.org/). If you don
 
 ### Manually
 
-If you're not using Composer, you can also download [the latest version of Omise-PHP](https://github.com/omise/omise-php/archive/v2.11.0.zip).
+If you're not using Composer, you can also download [the latest version of Omise-PHP](https://github.com/omise/omise-php/archive/v2.11.1.zip).
 Then, follows the instruction below to install **Omise-PHP** to the project.
 
 1. Extract the library to your project.

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -1,6 +1,6 @@
 <?php
 
-define('OMISE_PHP_LIB_VERSION', '2.11.0');
+define('OMISE_PHP_LIB_VERSION', '2.11.1');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 


### PR DESCRIPTION
**Hello everyone,**
We have released Omise-PHP v2.11.0 recently and one of changes in that release was aiming to drop support for PHP v5.3 and below.

Unfortunately, from the release, we also accidentally using some syntax that does not support in PHP v5.4 and v5.5 as well.

Here is a patch to make Omise-PHP be able to run under PHPv 5.4 and v5.5 enviroments.

> Note: we recommend everyone to switch your server environment to use PHP v5.6 and above as all the rest are at the End Of Life stage already. (no support, no patch, and no security patch update)


### This release contains 1 PRs as below:

#### ✨ Highlights

- **PR #106**: Fixes issue with use of array constant (mandated PHP 5.6+)

---

And don't forget to check our full-detail release note at https://github.com/omise/omise-php/releases
Also, feel free to create a [ticket](https://github.com/omise/omise-php/issues) or leave your comment below if you have any questions.

See you next release.
Cheers! 🍻 👏 