### PR TITLE
[dev v3.0] Merging Omise-PHP release 2.11.1 to `dev-3-0-0` branch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+### [v2.11.1 _(Jan 16, 2019)_](https://github.com/omise/omise-php/releases/tag/v2.11.1)
+
+#### 👾 Bug Fixes
+
+- Fixes issue with use of array constant (mandated PHP 5.6+). (PR [#106](https://github.com/omise/omise-php/pull/106))
+
+---
+
 ### [v2.11.0 _(Jan 9, 2019)_](https://github.com/omise/omise-php/releases/tag/v2.11.0)
 
 #### ✨ Highlights

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can install the library via [Composer](https://getcomposer.org/). If you don
 
 ### Manually
 
-If you're not using Composer, you can also download [the latest version of Omise-PHP](https://github.com/omise/omise-php/archive/v2.11.0.zip).
+If you're not using Composer, you can also download [the latest version of Omise-PHP](https://github.com/omise/omise-php/archive/v2.11.1.zip).
 Then, follows the instruction below to install **Omise-PHP** to the project.
 
 1. Extract the library to your project.

--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -7,9 +7,9 @@ class OmiseCapabilities extends OmiseApiResource
     /**
      * @var array  of the filterable keys.
      */
-    const FILTERS = array(
-        'backend' => array('currency', 'type', 'chargeAmount')
-    );
+    static $filters = [
+        'backend' => ['currency', 'type', 'chargeAmount']
+    ];
 
     protected function __construct($publickey = null, $secretkey = null)
     {
@@ -25,14 +25,14 @@ class OmiseCapabilities extends OmiseApiResource
      */
     protected function setupFilterShortcuts()
     {
-        foreach (self::FILTERS as $filterSubject => $availableFilters) {
+        foreach (self::$filters as $filterSubject => $availableFilters) {
             $filterArrayName = $filterSubject . 'Filter';
-            $this->$filterArrayName = array();
+            $this->$filterArrayName = [];
             $tempArr = &$this->$filterArrayName;
             foreach ($availableFilters as $type) {
                 $funcName = 'make' . ucfirst($filterSubject) . 'Filter' . $type;
                 $tempArr[$type] = function () use ($funcName) {
-                    return call_user_func_array(array($this, $funcName), func_get_args());
+                    return call_user_func_array([$this, $funcName], func_get_args());
                 };
             }
         }


### PR DESCRIPTION
There is a new release on Omise-PHP, v2.11.1 that solved some issue of PHP version.
Here is to merge the release to `dev-3-0-0` branch.

> Note: CircleCI still shows as failure, it is because `OmiseCapabilities` class is still referring back to `OmiseApiResource` which no longer exists (this class has been added namespace as `Omise\Res\OmiseApiResource`).
> This issue will be solved in the next coming pull request.