### PR TITLE
Changes hacked instalment minimum to 300000 subunits

### DIFF
--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -3,6 +3,7 @@
 class OmiseCapabilities extends OmiseApiResource
 {
     const ENDPOINT = 'capability';
+    const INSTALLMENT_MINIMUM = 300000;
 
     /**
      * @var array  of the filterable keys.
@@ -122,9 +123,9 @@ class OmiseCapabilities extends OmiseApiResource
         $defMin = $this['limits']['charge_amount']['min'];
         $defMax = $this['limits']['charge_amount']['max'];
         return function ($backend) use ($amount, $defMin, $defMax) {
-            // temporary hack for now to correct min value for instalments to 500000
+            // temporary hack for now to correct min value for instalments to fixed minium (different to normal charge minimum)
             if ($backend->type == 'installment') {
-                $min = 500000;
+                $min = self::INSTALLMENT_MINIMUM;
             } else {
                 $min = empty($backend->amount['min']) ? $defMin : $backend->amount['min'];
             }


### PR DESCRIPTION
#### 1. Objective

According to our intelligence, the minimum amount that can be charged with Installment payment method has been lowered to 3,000 THB per transaction.

This pull request is the fix. Thanks @jonrandy for updating the code.

