### PR TITLE
Introducing Omise\Omise class to manage all credential setting & retrieving

### DIFF
--- a/lib/Account.php
+++ b/lib/Account.php
@@ -10,14 +10,11 @@ class Account extends OmiseApiResource
     /**
      * Retrieves an account.
      *
-     * @param  string $publickey
-     * @param  string $secretkey
-     *
      * @return OmiseAccount
      */
-    public static function retrieve($publickey = null, $secretkey = null)
+    public static function retrieve()
     {
-        return parent::g_retrieve(get_class(), self::getUrl(), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl());
     }
 
     /**

--- a/lib/Balance.php
+++ b/lib/Balance.php
@@ -10,14 +10,11 @@ class Balance extends OmiseApiResource
     /**
      * Retrieves a current balance in the account.
      *
-     * @param  string $publickey
-     * @param  string $secretkey
-     *
      * @return OmiseBalance
      */
-    public static function retrieve($publickey = null, $secretkey = null)
+    public static function retrieve()
     {
-        return parent::g_retrieve(get_class(), self::getUrl(), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl());
     }
 
     /**

--- a/lib/Capabilities.php
+++ b/lib/Capabilities.php
@@ -14,9 +14,9 @@ class Capabilities extends OmiseApiResource
         'backend' => ['currency', 'type', 'chargeAmount']
     ];
 
-    protected function __construct($publickey = null, $secretkey = null)
+    protected function __construct()
     {
-        parent::__construct($publickey, $secretkey);
+        parent::__construct();
         $this->setupFilterShortcuts();
     }
 
@@ -44,14 +44,11 @@ class Capabilities extends OmiseApiResource
     /**
      * Retrieves capabilities.
      *
-     * @param  string $publickey
-     * @param  string $secretkey
-     *
      * @return OmiseCapabilities
      */
-    public static function retrieve($publickey = null, $secretkey = null)
+    public static function retrieve()
     {
-        return parent::g_retrieve(get_class(), self::getUrl(), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl());
     }
 
     /**

--- a/lib/Card.php
+++ b/lib/Card.php
@@ -15,12 +15,10 @@ class Card extends OmiseApiResource
      *
      * @param array  $array
      * @param string $customerID
-     * @param string $publickey
-     * @param string $secretkey
      */
-    public function __construct($array, $customerID, $publickey = null, $secretkey = null)
+    public function __construct($array, $customerID)
     {
-        parent::__construct($publickey, $secretkey);
+        parent::__construct();
 
         $this->_customerID = $customerID;
         $this->refresh($array);

--- a/lib/CardList.php
+++ b/lib/CardList.php
@@ -13,12 +13,10 @@ class CardList extends OmiseApiResource
     /**
      * @param array  $cards
      * @param string $customerID
-     * @param string $publickey
-     * @param string $secretkey
      */
-    public function __construct($cards, $customerID, $publickey = null, $secretkey = null)
+    public function __construct($cards, $customerID)
     {
-        parent::__construct($publickey, $secretkey);
+        parent::__construct();
         $this->_customerID = $customerID;
         $this->refresh($cards);
     }
@@ -34,7 +32,7 @@ class CardList extends OmiseApiResource
     {
         $result = $this->apiRequestor->get($this->getUrl($id), self::getResourceKey());
 
-        return new Card($result, $this->_customerID, $this->_publickey, $this->_secretkey);
+        return new Card($result, $this->_customerID);
     }
   
 

--- a/lib/Charge.php
+++ b/lib/Charge.php
@@ -16,28 +16,24 @@ class Charge extends OmiseApiResource
      * Retrieves a charge.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseCharge
      */
-    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    public static function retrieve($id = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**
      * Search for charges.
      *
      * @param  string $query
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSearch
      */
-    public static function search($query = '', $publickey = null, $secretkey = null)
+    public static function search($query = '')
     {
-        return Search::scope('charge', $publickey, $secretkey)->query($query);
+        return Search::scope('charge')->query($query);
     }
 
     /**
@@ -58,28 +54,24 @@ class Charge extends OmiseApiResource
      * Schedule a charge.
      *
      * @param  string $params
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseScheduler
      */
-    public static function schedule($params, $publickey = null, $secretkey = null)
+    public static function schedule($params)
     {
-        return new Scheduler('charge', $params, $publickey, $secretkey);
+        return new Scheduler('charge', $params);
     }
 
     /**
      * Creates a new charge.
      *
      * @param  array  $params
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseCharge
      */
-    public static function create($params, $publickey = null, $secretkey = null)
+    public static function create($params)
     {
-        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+        return parent::g_create(get_class(), self::getUrl(), $params);
     }
 
     /**
@@ -113,7 +105,7 @@ class Charge extends OmiseApiResource
     public function refund($params)
     {
         $result = $this->apiRequestor->post(self::getUrl($this['id']) . '/refunds', parent::getResourceKey(), $params);
-        return new Refund($result, $this->_publickey, $this->_secretkey);
+        return new Refund($result);
     }
 
     /**
@@ -142,25 +134,23 @@ class Charge extends OmiseApiResource
             $refunds = $this['refunds'];
         }
 
-        return new RefundList($refunds, $this['id'], $this->_publickey, $this->_secretkey);
+        return new RefundList($refunds, $this['id']);
     }
 
     /**
      * Gets a list of charge schedules.
      *
      * @param  array|string $options
-     * @param  string       $publickey
-     * @param  string       $secretkey
      *
      * @return OmiseScheduleList
      */
-    public static function schedules($options = array(), $publickey = null, $secretkey = null)
+    public static function schedules($options = array())
     {
         if (is_array($options)) {
             $options = '?' . http_build_query($options);
         }
 
-        return parent::g_retrieve('\Omise\ScheduleList', self::getUrl('schedules' . $options), $publickey, $secretkey);
+        return parent::g_retrieve('\Omise\ScheduleList', self::getUrl('schedules' . $options));
     }
 
     /**

--- a/lib/Customer.php
+++ b/lib/Customer.php
@@ -14,42 +14,36 @@ class Customer extends OmiseApiResource
      * Retrieves a customer.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseCustomer
      */
-    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    public static function retrieve($id = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**
      * Search for customers.
      *
      * @param  string $query
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSearch
      */
-    public static function search($query = '', $publickey = null, $secretkey = null)
+    public static function search($query = '')
     {
-        return Search::scope('customer', $publickey, $secretkey)->query($query);
+        return Search::scope('customer')->query($query);
     }
 
     /**
      * Creates a new customer.
      *
      * @param  array  $params
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseCustomer
      */
-    public static function create($params, $publickey = null, $secretkey = null)
+    public static function create($params)
     {
-        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+        return parent::g_create(get_class(), self::getUrl(), $params);
     }
 
     /**
@@ -111,7 +105,7 @@ class Customer extends OmiseApiResource
             $cards = $this['cards'];
         }
 
-        return new CardList($cards, $this['id'], $this->_publickey, $this->_secretkey);
+        return new CardList($cards, $this['id']);
     }
   
     /**
@@ -140,7 +134,7 @@ class Customer extends OmiseApiResource
                 $options = '?' . http_build_query($options);
             }
 
-            return parent::g_retrieve('\Omise\ScheduleList', self::getUrl($this['id'] . '/schedules' . $options), $this->_publickey, $this->_secretkey);
+            return parent::g_retrieve('\Omise\ScheduleList', self::getUrl($this['id'] . '/schedules' . $options));
         }
     }
 

--- a/lib/Dispute.php
+++ b/lib/Dispute.php
@@ -12,28 +12,24 @@ class Dispute extends OmiseApiResource
      * Retrieves a dispute.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseDispute
      */
-    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    public static function retrieve($id = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**
      * Search for disputes.
      *
      * @param  string $query
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSearch
      */
-    public static function search($query = '', $publickey = null, $secretkey = null)
+    public static function search($query = '')
     {
-        return Search::scope('dispute', $publickey, $secretkey)->query($query);
+        return Search::scope('dispute')->query($query);
     }
 
     /**

--- a/lib/Event.php
+++ b/lib/Event.php
@@ -11,14 +11,12 @@ class Event extends OmiseApiResource
      * Retrieves an event.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseEvent
      */
-    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    public static function retrieve($id = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**

--- a/lib/Forex.php
+++ b/lib/Forex.php
@@ -11,14 +11,12 @@ class Forex extends OmiseApiResource
      * Retrieves a forex data.
      *
      * @param  string $currency
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseForex
      */
-    public static function retrieve($currency = '', $publickey = null, $secretkey = null)
+    public static function retrieve($currency = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($currency), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($currency));
     }
 
     /**

--- a/lib/Link.php
+++ b/lib/Link.php
@@ -12,28 +12,24 @@ class Link extends OmiseApiResource
      * Retrieves a link.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseLink
      */
-    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    public static function retrieve($id = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**
      * Search for links.
      *
      * @param  string $query
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSearch
      */
-    public static function search($query = '', $publickey = null, $secretkey = null)
+    public static function search($query = '')
     {
-        return Search::scope('link', $publickey, $secretkey)->query($query);
+        return Search::scope('link')->query($query);
     }
 
     /**
@@ -54,14 +50,12 @@ class Link extends OmiseApiResource
      * Creates a new link.
      *
      * @param  array  $params
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseLink
      */
-    public static function create($params, $publickey = null, $secretkey = null)
+    public static function create($params)
     {
-        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+        return parent::g_create(get_class(), self::getUrl(), $params);
     }
 
     /**

--- a/lib/Occurrence.php
+++ b/lib/Occurrence.php
@@ -11,14 +11,12 @@ class Occurrence extends OmiseApiResource
      * Retrieves an occurence object.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseOccurrence
      */
-    public static function retrieve($id, $publickey = null, $secretkey = null)
+    public static function retrieve($id)
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     public function reload()

--- a/lib/OccurrenceList.php
+++ b/lib/OccurrenceList.php
@@ -13,6 +13,6 @@ class OccurrenceList extends OmiseApiResource
      */
     public function retrieve($id)
     {
-        return Occurrence::retrieve($id, $this->_publickey, $this->_secretkey);
+        return Occurrence::retrieve($id);
     }
 }

--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -1,4 +1,126 @@
 <?php
+namespace Omise;
+
+/**
+ * @method public static publicKey
+ * @method public static secretKey
+ * @method public static apiVersion
+ * @method public static userAgent
+ * @method public static setPublicKey
+ * @method public static setSecretKey
+ * @method public static setApiVersion
+ * @method public static setUserAgent
+ *
+ * @since 3.0.0
+ */
+class Omise
+{
+    /**
+     * @var string  Of Omise credentials (public key, secret key).
+     */
+    protected static $publicKey;
+    protected static $secretKey;
+
+    /**
+     * @var string  Of Omise API version.
+     */
+    protected static $apiVersion;
+
+    /**
+     * @var string  Of a custom USER-AGENT.
+     */
+    protected static $userAgent;
+
+    /**
+     * @return string
+     */
+    public static function publicKey()
+    {
+        // Backward compatible with v2.x and below.
+        if (is_null(static::$publicKey) && defined('OMISE_PUBLIC_KEY')) {
+            Omise::setPublicKey(OMISE_PUBLIC_KEY);
+        }
+
+        return static::$publicKey;
+    }
+
+    /**
+     * @return string
+     */
+    public static function secretKey()
+    {
+        // Backward compatible with v2.x and below.
+        if (is_null(static::$secretKey) && defined('OMISE_SECRET_KEY')) {
+            Omise::setSecretKey(OMISE_SECRET_KEY);
+        }
+
+        return static::$secretKey;
+    }
+
+    /**
+     * @return string
+     */
+    public static function apiVersion()
+    {
+        // Backward compatible with v2.x and below.
+        if (is_null(static::$apiVersion) && defined('OMISE_API_VERSION')) {
+            Omise::setApiVersion(OMISE_API_VERSION);
+        }
+
+        return static::$apiVersion;
+    }
+
+    /**
+     * @return string
+     */
+    public static function userAgent()
+    {
+        // Backward compatible with v2.x and below.
+        if (is_null(static::$userAgent) && defined('OMISE_USER_AGENT_SUFFIX')) {
+            Omise::setUserAgent(OMISE_USER_AGENT_SUFFIX);
+        }
+
+        return static::$userAgent;
+    }
+
+    /**
+     * @param string $key
+     */
+    public static function setPublicKey($key)
+    {
+        static::$publicKey = $key;
+    }
+
+    /**
+     * @param string $key
+     */
+    public static function setSecretKey($key)
+    {
+        static::$secretKey = $key;
+    }
+
+    /**
+     * @param string $version  Of a specific Omise API version.
+     *                         All available options are as follow:
+     *                           • 2014-07-27
+     *                           • 2015-11-17
+     *                           • 2017-11-02
+     *                           • 2019-05-29
+     */
+    public static function setApiVersion($version)
+    {
+        static::$apiVersion = $version;
+    }
+
+    /**
+     * @param string $userAgent
+     */
+    public static function setUserAgent($userAgent)
+    {
+        static::$userAgent = $userAgent;
+    }
+}
+
 // Cores and utilities.
 require_once dirname(__FILE__).'/omise/ApiRequestor.php';
 require_once dirname(__FILE__).'/omise/res/obj/OmiseObject.php';

--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -15,6 +15,8 @@ namespace Omise;
  */
 class Omise
 {
+    const VERSION = '3.0.0-dev';
+
     /**
      * @var string  Of Omise credentials (public key, secret key).
      */

--- a/lib/Recipient.php
+++ b/lib/Recipient.php
@@ -13,42 +13,36 @@ class Recipient extends OmiseApiResource
      * Retrieves recipients.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseRecipient
      */
-    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    public static function retrieve($id = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**
      * Search for recipients.
      *
      * @param  string $query
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSearch
      */
-    public static function search($query = '', $publickey = null, $secretkey = null)
+    public static function search($query = '')
     {
-        return Search::scope('recipient', $publickey, $secretkey)->query($query);
+        return Search::scope('recipient')->query($query);
     }
 
     /**
      * Creates a new recipient.
      *
      * @param  array  $params
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseRecipient
      */
-    public static function create($params, $publickey = null, $secretkey = null)
+    public static function create($params)
     {
-        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+        return parent::g_create(get_class(), self::getUrl(), $params);
     }
 
     /**
@@ -109,7 +103,7 @@ class Recipient extends OmiseApiResource
                 $options = '?' . http_build_query($options);
             }
 
-            return parent::g_retrieve('\Omise\ScheduleList', self::getUrl($this['id'] . '/schedules' . $options), $this->_publickey, $this->_secretkey);
+            return parent::g_retrieve('\Omise\ScheduleList', self::getUrl($this['id'] . '/schedules' . $options));
         }
     }
 

--- a/lib/Refund.php
+++ b/lib/Refund.php
@@ -7,13 +7,11 @@ use Omise\Search;
 class Refund extends OmiseApiResource
 {
     /**
-     * @param array  $refund
-     * @param string $publickey
-     * @param string $secretkey
+     * @param array $refund
      */
-    public function __construct($refund, $publickey = null, $secretkey = null)
+    public function __construct($refund)
     {
-        parent::__construct($publickey, $secretkey);
+        parent::__construct();
         $this->refresh($refund);
     }
 
@@ -21,13 +19,11 @@ class Refund extends OmiseApiResource
      * Search for refunds.
      *
      * @param  string $query
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSearch
      */
-    public static function search($query = '', $publickey = null, $secretkey = null)
+    public static function search($query = '')
     {
-        return Search::scope('refund', $publickey, $secretkey)->query($query);
+        return Search::scope('refund')->query($query);
     }
 }

--- a/lib/RefundList.php
+++ b/lib/RefundList.php
@@ -13,12 +13,10 @@ class RefundList extends OmiseApiResource
     /**
      * @param array  $refunds
      * @param string $chargeID
-     * @param string $publickey
-     * @param string $secretkey
      */
-    public function __construct($refunds, $chargeID, $publickey = null, $secretkey = null)
+    public function __construct($refunds, $chargeID)
     {
-        parent::__construct($publickey, $secretkey);
+        parent::__construct();
         $this->_chargeID = $chargeID;
         $this->refresh($refunds);
     }
@@ -32,7 +30,7 @@ class RefundList extends OmiseApiResource
     {
         $result = $this->apiRequestor->post($this->getUrl(), self::getResourceKey(), $params);
 
-        return new Refund($result, $this->_publickey, $this->_secretkey);
+        return new Refund($result);
     }
 
     /**
@@ -44,7 +42,7 @@ class RefundList extends OmiseApiResource
     {
         $result = $this->apiRequestor->get($this->getUrl($id), self::getResourceKey());
 
-        return new Refund($result, $this->_publickey, $this->_secretkey);
+        return new Refund($result);
     }
 
     /**

--- a/lib/Schedule.php
+++ b/lib/Schedule.php
@@ -12,14 +12,12 @@ class Schedule extends OmiseApiResource
      * Retrieves a schedule.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSchedule
      */
-    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    public static function retrieve($id = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**
@@ -38,14 +36,12 @@ class Schedule extends OmiseApiResource
      * Creates a new schedule.
      *
      * @param  array  $params
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSchedule
      */
-    public static function create($params, $publickey = null, $secretkey = null)
+    public static function create($params)
     {
-        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+        return parent::g_create(get_class(), self::getUrl(), $params);
     }
 
     /**
@@ -60,7 +56,7 @@ class Schedule extends OmiseApiResource
                 $options = '?' . http_build_query($options);
             }
 
-            return parent::g_retrieve('\Omise\OccurrenceList', self::getUrl($this['id'] . '/occurrences' . $options), $this->_publickey, $this->_secretkey);
+            return parent::g_retrieve('\Omise\OccurrenceList', self::getUrl($this['id'] . '/occurrences' . $options));
         }
     }
 

--- a/lib/ScheduleList.php
+++ b/lib/ScheduleList.php
@@ -13,6 +13,6 @@ class ScheduleList extends OmiseApiResource
      */
     public function retrieve($id)
     {
-        return Schedule::retrieve($id, $this->_publickey, $this->_secretkey);
+        return Schedule::retrieve($id);
     }
 }

--- a/lib/Scheduler.php
+++ b/lib/Scheduler.php
@@ -13,12 +13,10 @@ class Scheduler extends OmiseApiResource
      *
      * @param string $type        Either 'charge' or 'transfer'
      * @param string $attributes  See supported attributes at [Charge Schedule API](https://www.omise.co/charge-schedules-api#charge_schedules-create) page.
-     * @param string $publickey
-     * @param string $secretkey
      */
-    public function __construct($type, $attributes = array(), $publickey = null, $secretkey = null)
+    public function __construct($type, $attributes = array())
     {
-        parent::__construct($publickey, $secretkey);
+        parent::__construct();
 
         $this->mergeAttributes($type, $attributes);
     }

--- a/lib/Search.php
+++ b/lib/Search.php
@@ -33,14 +33,12 @@ class Search extends OmiseApiResource
      * Create an instance of `OmiseSearch` with the given scope.
      *
      * @param  string $scope  See supported scope at [Search API](https://www.omise.co/search-api) page.
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSearch  The created instance.
      */
-    public static function scope($scope, $publickey = null, $secretkey = null)
+    public static function scope($scope)
     {
-        return new static($scope, $publickey, $secretkey);
+        return new static($scope);
     }
 
     /**
@@ -49,12 +47,10 @@ class Search extends OmiseApiResource
      * This constructor is `protected` thus not intended to be used directly.
      *
      * @param string $scope  See supported scope at [Search API](https://www.omise.co/search-api) page.
-     * @param string $publickey
-     * @param string $secretkey
      */
-    protected function __construct($scope, $publickey, $secretkey)
+    protected function __construct($scope)
     {
-        parent::__construct($publickey, $secretkey);
+        parent::__construct();
         $this->mergeAttributes('scope', $scope);
     }
 

--- a/lib/Source.php
+++ b/lib/Source.php
@@ -10,15 +10,13 @@ class Source extends OmiseApiResource
     /**
      * Creates a new source.
      *
-     * @param  array  $params
-     * @param  string $publickey
-     * @param  string $secretkey
+     * @param  array $params
      *
      * @return OmiseSource
      */
-    public static function create($params, $publickey = null, $secretkey = null)
+    public static function create($params)
     {
-        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+        return parent::g_create(get_class(), self::getUrl(), $params);
     }
 
     /**

--- a/lib/Token.php
+++ b/lib/Token.php
@@ -11,29 +11,25 @@ class Token extends OmiseVaultResource
      * Retrieves a token.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseToken
      */
-    public static function retrieve($id, $publickey = null, $secretkey = null)
+    public static function retrieve($id)
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**
      * Creates a new token. Please note that this method should be used only
      * in development. In production please use Omise.js!
      *
-     * @param  array  $params
-     * @param  string $publickey
-     * @param  string $secretkey
+     * @param  array $params
      *
      * @return OmiseToken
      */
-    public static function create($params, $publickey = null, $secretkey = null)
+    public static function create($params)
     {
-        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+        return parent::g_create(get_class(), self::getUrl(), $params);
     }
 
     /**

--- a/lib/Transaction.php
+++ b/lib/Transaction.php
@@ -11,14 +11,12 @@ class Transaction extends OmiseApiResource
      * Retrieves a transaction.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseTransaction
      */
-    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    public static function retrieve($id = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**

--- a/lib/Transfer.php
+++ b/lib/Transfer.php
@@ -14,56 +14,48 @@ class Transfer extends OmiseApiResource
      * Retrieves a transfer.
      *
      * @param  string $id
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseTransfer
      */
-    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    public static function retrieve($id = '')
     {
-        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+        return parent::g_retrieve(get_class(), self::getUrl($id));
     }
 
     /**
      * Search for transfers.
      *
      * @param  string $query
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseSearch
      */
-    public static function search($query = '', $publickey = null, $secretkey = null)
+    public static function search($query = '')
     {
-        return Search::scope('transfer', $publickey, $secretkey)->query($query);
+        return Search::scope('transfer')->query($query);
     }
 
     /**
      * Schedule a transfer.
      *
      * @param  string $params
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseScheduler
      */
-    public static function schedule($params, $publickey = null, $secretkey = null)
+    public static function schedule($params)
     {
-        return new Scheduler('transfer', $params, $publickey, $secretkey);
+        return new Scheduler('transfer', $params);
     }
 
     /**
      * Creates a transfer.
      *
      * @param  mixed  $params
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @return OmiseTransfer
      */
-    public static function create($params, $publickey = null, $secretkey = null)
+    public static function create($params)
     {
-        return parent::g_create(get_class(), self::getUrl(), $params, $publickey, $secretkey);
+        return parent::g_create(get_class(), self::getUrl(), $params);
     }
 
     /**
@@ -102,18 +94,16 @@ class Transfer extends OmiseApiResource
      * Gets a list of transfer schedules.
      *
      * @param  array|string $options
-     * @param  string       $publickey
-     * @param  string       $secretkey
      *
      * @return OmiseScheduleList
      */
-    public static function schedules($options = array(), $publickey = null, $secretkey = null)
+    public static function schedules($options = array())
     {
         if (is_array($options)) {
             $options = '?' . http_build_query($options);
         }
 
-        return parent::g_retrieve('\Omise\ScheduleList', self::getUrl('schedules' . $options), $publickey, $secretkey);
+        return parent::g_retrieve('\Omise\ScheduleList', self::getUrl('schedules' . $options));
     }
 
     /**

--- a/lib/omise/ApiRequestor.php
+++ b/lib/omise/ApiRequestor.php
@@ -172,15 +172,15 @@ class ApiRequestor
         );
 
         // Config Omise API Version
-        if (defined('OMISE_API_VERSION')) {
-            $options += array(CURLOPT_HTTPHEADER => array('Omise-Version: ' . OMISE_API_VERSION));
+        if ($apiVersion = \Omise\Omise::apiVersion()) {
+            $options += array(CURLOPT_HTTPHEADER => array('Omise-Version: ' . $apiVersion));
 
-            $userAgent .= ' OmiseAPI/' . OMISE_API_VERSION;
+            $userAgent .= ' OmiseAPI/' . $apiVersion;
         }
 
         // Config UserAgent
-        if (defined('OMISE_USER_AGENT_SUFFIX')) {
-            $userAgent .= $userAgent . ' ' . OMISE_USER_AGENT_SUFFIX;
+        if ($suffixUserAgent = \Omise\Omise::userAgent()) {
+            $userAgent .= ' ' . $suffixUserAgent;
         }
 
         $options += array(CURLOPT_USERAGENT => $userAgent);

--- a/lib/omise/ApiRequestor.php
+++ b/lib/omise/ApiRequestor.php
@@ -9,7 +9,6 @@ class ApiRequestor
     /**
      * @var string
      */
-    const OMISE_PHP_LIB_VERSION = '3.0.0-dev';
     const OMISE_API_URL         = 'https://api.omise.co/';
     const OMISE_VAULT_URL       = 'https://vault.omise.co/';
 
@@ -156,7 +155,7 @@ class ApiRequestor
     private function genOptions($requestMethod, $userpassword, $params)
     {
         $certificateFileLocation = dirname(__FILE__) . '/../../data/ca_certificates.pem';
-        $userAgent               = 'OmisePHP/' . self::OMISE_PHP_LIB_VERSION . ' PHP/' . phpversion();
+        $userAgent               = 'OmisePHP/' . \Omise\Omise::VERSION . ' PHP/' . phpversion();
 
         $options = array(
             CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,       // Set the HTTP version to 1.1.

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -9,13 +9,9 @@ class OmiseApiResource extends OmiseObject
 {
     public $apiRequestor;
 
-    /**
-     * @param string $publickey
-     * @param string $secretkey
-     */
-    protected function __construct($publickey = null, $secretkey = null)
+    protected function __construct()
     {
-        parent::__construct($publickey, $secretkey);
+        parent::__construct();
         $this->apiRequestor = new ApiRequestor;
     }
 
@@ -23,36 +19,33 @@ class OmiseApiResource extends OmiseObject
      * Returns an instance of the class given in $clazz or raise an error.
      *
      * @param  string $clazz
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @throws Exception
      *
      * @return OmiseResource
      */
-    protected static function getInstance($clazz, $publickey = null, $secretkey = null)
+    protected static function getInstance($clazz)
     {
-        if (class_exists($clazz)) {
-            return new $clazz($publickey, $secretkey);
+        if (! class_exists($clazz)) {
+            throw new Exception('Undefined class.');
         }
 
-        throw new Exception('Undefined class.');
+        return new $clazz;
     }
 
     /**
      * Retrieves the resource.
      *
      * @param  string $clazz
-     * @param  string $publickey
-     * @param  string $secretkey
+     * @param  string $url
      *
      * @throws Exception|OmiseException
      *
      * @return OmiseAccount|OmiseBalance|OmiseCharge|OmiseCustomer|OmiseToken|OmiseTransaction|OmiseTransfer
      */
-    protected static function g_retrieve($clazz, $url, $publickey = null, $secretkey = null)
+    protected static function g_retrieve($clazz, $url)
     {
-        $resource = call_user_func(array($clazz, 'getInstance'), $clazz, $publickey, $secretkey);
+        $resource = call_user_func(array($clazz, 'getInstance'), $clazz);
         $result   = $resource->apiRequestor->get($url, $resource->getResourceKey());
         $resource->refresh($result);
 
@@ -65,16 +58,14 @@ class OmiseApiResource extends OmiseObject
      * @param  string $clazz
      * @param  string $url
      * @param  array  $params
-     * @param  string $publickey
-     * @param  string $secretkey
      *
      * @throws Exception|OmiseException
      *
      * @return OmiseAccount|OmiseBalance|OmiseCharge|OmiseCustomer|OmiseToken|OmiseTransaction|OmiseTransfer
      */
-    protected static function g_create($clazz, $url, $params, $publickey = null, $secretkey = null)
+    protected static function g_create($clazz, $url, $params)
     {
-        $resource = call_user_func(array($clazz, 'getInstance'), $clazz, $publickey, $secretkey);
+        $resource = call_user_func(array($clazz, 'getInstance'), $clazz);
         $result   = $resource->apiRequestor->post($url, $resource->getResourceKey(), $params);
         $resource->refresh($result);
 

--- a/lib/omise/res/obj/OmiseObject.php
+++ b/lib/omise/res/obj/OmiseObject.php
@@ -15,25 +15,12 @@ class OmiseObject implements \ArrayAccess, \Iterator, \Countable
     /**
      * Setup the Omise object. If no secret and public are passed the one defined
      * in config.php will be used.
-     *
-     * @param string $publickey
-     * @param string $secretkey
      */
-    protected function __construct($publickey = null, $secretkey = null)
+    protected function __construct()
     {
-        if ($publickey !== null) {
-            $this->_publickey = $publickey;
-        } else {
-            $this->_publickey = OMISE_PUBLIC_KEY;
-        }
-
-        if ($secretkey !== null) {
-            $this->_secretkey = $secretkey;
-        } else {
-            $this->_secretkey = OMISE_SECRET_KEY;
-        }
-
-        $this->_values = array();
+        $this->_values    = array();
+        $this->_publickey = \Omise\Omise::publicKey();
+        $this->_secretkey = \Omise\Omise::secretKey();
     }
 
     /**


### PR DESCRIPTION
### 1. Objective

This is the very first part of refactoring for a better organizing constants and variables in Omise-PHP.
While `define('OMISE_SECRET_KEY', '')` works just fine, it's causing an 'immutable' variable problem.
As it reflects at all of resource classes that, Omise-PHP allows for on-the-fly ket setting (i.e. `OmiseAccount::retrieve('', 'new_pkey', 'new_skey')`).

If Omise-PHP will eventually allow user to alter the credential, then it at least, should not be set with an immutable constant variable but something that user can properly call to set a new credential, right?

**Omise\Omise** class provides useful static methods to organize all necessary variables that can be used across the entire library.
This class may, in the future, provide some sort of `Omise\Omise::setClient(OmiseClientInterface new OmiseTestClient);` to improve the test ability as well.

### 2. Description of change

1. Introducing a new class, `Omise\Omise`, to organize all necessary variables that can be used across the entire library.
 
2. Removing the ability to set a new credential (aka. public key and secret key) on-the-fly from all resource classes (OmiseAccount, OmiseBalance, OmiseCharge, and so on).

Now you can set Omise credential with the following code:
```php
\Omise\Omise::setPublicKey('pkey_test_5fcnkn4378pmguq5zpy');
\Omise\Omise::setSecretKey('skey_test_5fduue09qa7iantplkd');
\Omise\Omise::setApiVersion('2019-05-29');
\Omise\Omise::setUserAgent('CustomUserAgent/1.0');

$account = \Omise\Account::retrieve(); // or OmiseAccount::retrieve(); if you prefer without namespace.
```

### 3. Quality assurance

Use https://github.com/guzzilar/omise-php-examples repository to test all possible cases.
All code works as expected. Such as
- Retrieve
- Reload
- Create
- Update
- Delete
- Schedule
- Search

etc.

### 4. Impact of the change
It's a **breaking-change** for all developers that are assigning Omise keys on-the-fly by passing the credential through Omise resource classes.
For example:
```php
define('OMISE_PUBLIC_KEY', 'current_pkey_from_account_a');
define('OMISE_SECRET_KEY', 'current_skey_from_account_a');

$account = OmiseAccount::retrieve('new_pkey_from_account_b', 'new_skey_from_account_b');
```

This would no longer work as this approach removes those `$publickey`, `$secretkey` out from all resource classes.

However, these code will still work just fine.
```php
define('OMISE_PUBLIC_KEY', 'current_pkey_from_account_a');
define('OMISE_SECRET_KEY', 'current_skey_from_account_a');
define('OMISE_API_VERSION', '2019-**-**');
define('OMISE_USER_AGENT_SUFFIX', 'CustomUserAgent/1.0');
```
For all of those developers who have implemented with the previous `define` approach, this way works as normal (backward compatibility).

### 5. Priority of change

Normal, but this PR should be merged before the release `v3.0.0-rc1`.

### 6. Additional Notes

All inputs are always welcome.