### PR TITLE
Refactoring, decoupling part of the code out from OmiseApiResource – Introducing Client class

### DIFF
--- a/lib/Client/ClientInterface.php
+++ b/lib/Client/ClientInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Omise\Client;
+
+interface ClientInterface
+{
+    /**
+     * @param string $key
+     */
+    public function setCredential($key);
+
+    /**
+     * @param string $url     An API endpoint
+     * @param string $method  A HTTP request method
+     * @param array  $params  Request body
+     */
+    public function execute($url, $method, $params);
+}

--- a/lib/Client/CurlClient.php
+++ b/lib/Client/CurlClient.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Omise\Client;
+
+use Exception;
+
+class CurlClient implements ClientInterface
+{
+    /**
+     * @var string
+     */
+    protected static $credential;
+
+    /**
+     * Timeout setting
+     *
+     * @var int
+     */
+    private $OMISE_CONNECTTIMEOUT = 30;
+    private $OMISE_TIMEOUT        = 60;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setCredential($key)
+    {
+        static::$credential = $key;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($url, $method, $params)
+    {
+        $options = $this->genOptions($method, static::$credential . ':', $params);
+        $curl    = curl_init($url);
+
+        curl_setopt_array($curl, $options);
+
+        // Make a request or thrown an exception.
+        if (($result = curl_exec($curl)) === false) {
+            $error = curl_error($curl);
+            curl_close($curl);
+
+            throw new Exception($error);
+        }
+
+        curl_close($curl);
+        return $result;
+    }
+
+    /**
+     * Creates an option for php-curl from the given request method
+     * and parameters in an associative array.
+     *
+     * @param  string $requestMethod
+     * @param  string $userpassword
+     * @param  array  $params
+     *
+     * @return array
+     */
+    private function genOptions($requestMethod, $userpassword, $params)
+    {
+        $userAgent = 'OmisePHP/' . OMISE_PHP_LIB_VERSION . ' PHP/' . phpversion();
+
+        $options = array(
+            CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,       // Set the HTTP version to 1.1.
+            CURLOPT_CUSTOMREQUEST  => $requestMethod,              // Set the request method.
+            CURLOPT_RETURNTRANSFER => true,                        // Make php-curl returns the data as string.
+            CURLOPT_HEADER         => false,                       // Do not include the header in the output.
+            CURLINFO_HEADER_OUT    => true,                        // Track the header request string and set the referer on redirect.
+            CURLOPT_AUTOREFERER    => true,
+            CURLOPT_TIMEOUT        => $this->OMISE_TIMEOUT,        // Time before the request is aborted.
+            CURLOPT_CONNECTTIMEOUT => $this->OMISE_CONNECTTIMEOUT, // Time before the request is aborted when attempting to connect.
+            CURLOPT_USERPWD        => $userpassword                // Authentication.
+        );
+
+        // Config Omise API Version
+        if (defined('OMISE_API_VERSION')) {
+            $options += array(CURLOPT_HTTPHEADER => array('Omise-Version: ' . OMISE_API_VERSION));
+
+            $userAgent .= ' OmiseAPI/' . OMISE_API_VERSION;
+        }
+
+        // Config UserAgent
+        if (defined('OMISE_USER_AGENT_SUFFIX')) {
+            $userAgent .= ' ' . OMISE_USER_AGENT_SUFFIX;
+        }
+
+        $options += array(CURLOPT_USERAGENT => $userAgent);
+
+        // Also merge POST parameters with the option.
+        if (is_array($params) && count($params) > 0) {
+            $httpQuery = http_build_query($params);
+            $httpQuery = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $httpQuery);
+
+            $options += array(CURLOPT_POSTFIELDS => $httpQuery);
+        }
+
+        return $options;
+    }
+}

--- a/lib/Client/UnitTestClient.php
+++ b/lib/Client/UnitTestClient.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Omise\Client;
+
+use Exception;
+
+class UnitTestClient implements ClientInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function setCredential($key)
+    {
+        return;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute($url, $method, $params)
+    {
+        $fixtureDirectory = __DIR__ . '/../../tests/fixtures';
+        $requestUrl       = $this->extractRequestUrl($url);
+
+        $fixture = $fixtureDirectory . '/' . $requestUrl . '-' . strtolower($method) . '.json';
+        if (! file_exists($fixture)) {
+            throw new Exception('Fixture not found: ' . $fixture);
+        }
+
+        return file_get_contents($fixture);
+    }
+
+    protected function extractRequestUrl($url)
+    {
+        // Extract only hostname and URL path without trailing slash.
+        $parsed      = parse_url($url);
+        $requestUrl = $parsed['host'] . rtrim($parsed['path'], '/');
+
+        // Convert query string into filename friendly format.
+        if (! empty($parsed['query'])) {
+            $query      = base64_encode($parsed['query']);
+            $query      = str_replace(array('+', '/', '='), array('-', '_', ''), $query);
+            $requestUrl = $requestUrl . '-' . $query;
+        }
+
+        return $requestUrl;
+    }
+}

--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -1,5 +1,9 @@
 <?php
 // Cores and utilities.
+require_once dirname(__FILE__).'/Client/ClientInterface.php';
+require_once dirname(__FILE__).'/Client/CurlClient.php';
+require_once dirname(__FILE__).'/Client/UnitTestClient.php';
+
 require_once dirname(__FILE__).'/omise/res/obj/OmiseObject.php';
 require_once dirname(__FILE__).'/omise/res/OmiseApiResource.php';
 

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -12,10 +12,6 @@ class OmiseApiResource extends OmiseObject
     const REQUEST_DELETE = 'DELETE';
     const REQUEST_PATCH = 'PATCH';
 
-    // Timeout settings
-    private $OMISE_CONNECTTIMEOUT = 30;
-    private $OMISE_TIMEOUT = 60;
-
     /**
      * Returns an instance of the class given in $clazz or raise an error.
      *
@@ -135,10 +131,13 @@ class OmiseApiResource extends OmiseObject
     {
         // If this class is execute by phpunit > get test mode.
         if (preg_match('/phpunit/', $_SERVER['SCRIPT_NAME'])) {
-            $result = $this->_executeTest($url, $requestMethod, $key, $params);
+            $client = new \Omise\Client\UnitTestClient;
         } else {
-            $result = $this->_executeCurl($url, $requestMethod, $key, $params);
+            $client = new \Omise\Client\CurlClient;
         }
+
+        $client->setCredential($key);
+        $result = $client->execute($url, $requestMethod, $params);
 
         // Decode the JSON response as an associative array.
         $array = json_decode($result, true);
@@ -166,147 +165,6 @@ class OmiseApiResource extends OmiseObject
     protected function isValidAPIResponse($array)
     {
         return count($array) && isset($array['object']);
-    }
-
-    /**
-     * @param  string $url
-     * @param  string $requestMethod
-     * @param  array  $params
-     *
-     * @throws OmiseException
-     *
-     * @return string
-     */
-    private function _executeCurl($url, $requestMethod, $key, $params = null)
-    {
-        $ch = curl_init($url);
-
-        curl_setopt_array($ch, $this->genOptions($requestMethod, $key.':', $params));
-
-        // Make a request or thrown an exception.
-        if (($result = curl_exec($ch)) === false) {
-            $error = curl_error($ch);
-            curl_close($ch);
-
-            throw new Exception($error);
-        }
-
-        // Close.
-        curl_close($ch);
-
-        return $result;
-    }
-
-    /**
-     * @param  string $url
-     * @param  string $requestMethod
-     * @param  array  $params
-     *
-     * @throws OmiseException
-     *
-     * @return string
-     */
-    private function _executeTest($url, $requestMethod, $key, $params = null)
-    {
-        // Extract only hostname and URL path without trailing slash.
-        $parsed = parse_url($url);
-        $request_url = $parsed['host'] . rtrim($parsed['path'], '/');
-
-        // Convert query string into filename friendly format.
-        if (!empty($parsed['query'])) {
-            $query = base64_encode($parsed['query']);
-            $query = str_replace(array('+', '/', '='), array('-', '_', ''), $query);
-            $request_url = $request_url.'-'.$query;
-        }
-
-        // Finally.
-        $request_url = dirname(__FILE__).'/../../../tests/fixtures/'.$request_url.'-'.strtolower($requestMethod).'.json';
-
-        // Make a request from Curl if json file was not exists.
-        if (! file_exists($request_url)) {
-            // Get a directory that's file should contain.
-            $request_dir = explode('/', $request_url);
-            unset($request_dir[count($request_dir) - 1]);
-            $request_dir = implode('/', $request_dir);
-
-            // Create directory if it not exists.
-            if (! file_exists($request_dir)) {
-                mkdir($request_dir, 0777, true);
-            }
-
-            $result = $this->_executeCurl($url, $requestMethod, $key, $params);
-
-            $f = fopen($request_url, 'w');
-            if ($f) {
-                fwrite($f, $result);
-
-                fclose($f);
-            }
-        } else { // Or get response from json file.
-            $result = file_get_contents($request_url);
-        }
-
-        return $result;
-    }
-
-    /**
-     * Creates an option for php-curl from the given request method and parameters in an associative array.
-     *
-     * @param  string $requestMethod
-     * @param  array  $params
-     *
-     * @return array
-     */
-    private function genOptions($requestMethod, $userpwd, $params)
-    {
-        $user_agent        = "OmisePHP/".OMISE_PHP_LIB_VERSION." PHP/".phpversion();
-        $omise_api_version = defined('OMISE_API_VERSION') ? OMISE_API_VERSION : null;
-
-        $options = array(
-            // Set the HTTP version to 1.1.
-            CURLOPT_HTTP_VERSION   => CURL_HTTP_VERSION_1_1,
-            // Set the request method.
-            CURLOPT_CUSTOMREQUEST  => $requestMethod,
-            // Make php-curl returns the data as string.
-            CURLOPT_RETURNTRANSFER => true,
-            // Do not include the header in the output.
-            CURLOPT_HEADER         => false,
-            // Track the header request string and set the referer on redirect.
-            CURLINFO_HEADER_OUT    => true,
-            CURLOPT_AUTOREFERER    => true,
-            // Make HTTP error code above 400 an error.
-            // CURLOPT_FAILONERROR => true,
-            // Time before the request is aborted.
-            CURLOPT_TIMEOUT        => $this->OMISE_TIMEOUT,
-            // Time before the request is aborted when attempting to connect.
-            CURLOPT_CONNECTTIMEOUT => $this->OMISE_CONNECTTIMEOUT,
-            // Authentication.
-            CURLOPT_USERPWD        => $userpwd
-        );
-
-        // Config Omise API Version
-        if ($omise_api_version) {
-            $options += array(CURLOPT_HTTPHEADER => array("Omise-Version: ".$omise_api_version));
-
-            $user_agent .= ' OmiseAPI/'.$omise_api_version;
-        }
-
-        // Config UserAgent
-        if (defined('OMISE_USER_AGENT_SUFFIX')) {
-            $options += array(CURLOPT_USERAGENT => $user_agent." ".OMISE_USER_AGENT_SUFFIX);
-        } else {
-            $options += array(CURLOPT_USERAGENT => $user_agent);
-        }
-
-        // Also merge POST parameters with the option.
-        if (is_array($params) && count($params) > 0) {
-            $http_query = http_build_query($params);
-            $http_query = preg_replace('/%5B[0-9]+%5D/simU', '%5B%5D', $http_query);
-
-            $options += array(CURLOPT_POSTFIELDS => $http_query);
-        }
-
-        return $options;
     }
 
     /**


### PR DESCRIPTION
### Ojbective
Currently OmiseApiResource is coupled with many responsibilities, just make the code too fat, and too hard to test. This pull request is taking some part of the code that is responsible for making a request to Omise API out from its current class and move to those new client classes.

> Please note that this pull request wouldn't focus on refactoring anything much more than re-organizing the code.
>
> Eventually, **OmiseApiResource** should not worry about how to make a request to Omise API or how to handle HTTP body that is returned.
>
> So here I'm trying adding a layer for HTTP Requestor, Client, and HTTP Response handle classes (however, this pull request is introducing the HTTP Client layer first).

### Quality Assurance

- [x] **All test cases should be green**
- [x] **Test making POST request to make sure that the library is working properly**
```php
define('OMISE_PUBLIC_KEY', 'pkey_test_*******************');
define('OMISE_SECRET_KEY', 'skey_test_*******************');
define('OMISE_API_VERSION', '2017-11-02');
define('OMISE_USER_AGENT_SUFFIX', 'Test/0.1');

$customer = OmiseCustomer::create([
    'description' => rand(),
    'email'       => 'nam+customer' . rand() . '@omise.co'
]);
```

Result:
![Screen Shot 2562-08-26 at 09 25 46](https://user-images.githubusercontent.com/2154669/63661179-b1713200-c7e3-11e9-8405-d2cbffb07323.png)

- [x] **Test making GET and PATCH requests to make sure that the library is working properly**
```php
define('OMISE_PUBLIC_KEY', 'pkey_test_*******************');
define('OMISE_SECRET_KEY', 'skey_test_*******************');

$customer = OmiseCustomer::retrieve('cust_test_5h0tuupznl4dn7qhfh0');
$customer->update([
    'description' => 'Updated description'
]);
```

Result:
![Screen Shot 2562-08-26 at 09 33 10](https://user-images.githubusercontent.com/2154669/63661399-98b54c00-c7e4-11e9-81d6-72382802b89b.png)

- [x] **Test making DELETE request to make sure that the library is working properly**
```php
define('OMISE_PUBLIC_KEY', 'pkey_test_*******************');
define('OMISE_SECRET_KEY', 'skey_test_*******************');
define('OMISE_API_VERSION', '2019-05-29');

$customer = OmiseCustomer::retrieve('cust_test_5h0tyrqei5aocygx3yo');
$customer->destroy();
```

Result:
![Screen Shot 2562-08-26 at 09 36 55](https://user-images.githubusercontent.com/2154669/63661541-3741ad00-c7e5-11e9-98f5-8208bfe11ee3.png)