### PR TITLE
Strategy for dealing with old API versions without having to maintain multiple versions of the library

### DIFF
--- a/lib/omise/OmiseCardList.php
+++ b/lib/omise/OmiseCardList.php
@@ -28,7 +28,7 @@ class OmiseCardList extends OmiseApiResource
      */
     public function retrieve($id)
     {
-        $result = parent::execute($this->getUrl($id), parent::REQUEST_GET, self::getResourceKey());
+        list($result, $headers) = parent::execute($this->getUrl($id), parent::REQUEST_GET, self::getResourceKey());
 
         return new OmiseCard($result, $this->_customerID, $this->_publickey, $this->_secretkey);
     }

--- a/lib/omise/OmiseCharge.php
+++ b/lib/omise/OmiseCharge.php
@@ -91,7 +91,7 @@ class OmiseCharge extends OmiseApiResource
      */
     public function capture()
     {
-        $result = parent::execute(self::getUrl($this['id']).'/capture', parent::REQUEST_POST, parent::getResourceKey());
+        list($result, $headers) = parent::execute(self::getUrl($this['id']).'/capture', parent::REQUEST_POST, parent::getResourceKey());
         $this->refresh($result);
 
         return $this;
@@ -104,7 +104,7 @@ class OmiseCharge extends OmiseApiResource
      */
     public function refund($params)
     {
-        $result = parent::execute(self::getUrl($this['id']) . '/refunds', parent::REQUEST_POST, parent::getResourceKey(), $params);
+        list($result, $headers) = parent::execute(self::getUrl($this['id']) . '/refunds', parent::REQUEST_POST, parent::getResourceKey(), $params);
         return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
     }
 
@@ -115,7 +115,7 @@ class OmiseCharge extends OmiseApiResource
      */
     public function reverse()
     {
-        $result = parent::execute(self::getUrl($this['id']).'/reverse', parent::REQUEST_POST, parent::getResourceKey());
+        list($result, $headers) = parent::execute(self::getUrl($this['id']).'/reverse', parent::REQUEST_POST, parent::getResourceKey());
         $this->refresh($result);
 
         return $this;
@@ -129,7 +129,7 @@ class OmiseCharge extends OmiseApiResource
     public function refunds($options = array())
     {
         if (is_array($options) && ! empty($options)) {
-            $refunds = parent::execute(self::getUrl($this['id']) . '/refunds?' . http_build_query($options), parent::REQUEST_GET, parent::getResourceKey());
+            list($refunds, $headers) = parent::execute(self::getUrl($this['id']) . '/refunds?' . http_build_query($options), parent::REQUEST_GET, parent::getResourceKey());
         } else {
             $refunds = $this['refunds'];
         }

--- a/lib/omise/OmiseCustomer.php
+++ b/lib/omise/OmiseCustomer.php
@@ -100,7 +100,7 @@ class OmiseCustomer extends OmiseApiResource
     public function cards($options = array())
     {
         if (is_array($options) && ! empty($options)) {
-            $cards = parent::execute(self::getUrl($this['id']) . '/cards?' . http_build_query($options), parent::REQUEST_GET, parent::getResourceKey());
+            list($cards, $headers) = parent::execute(self::getUrl($this['id']) . '/cards?' . http_build_query($options), parent::REQUEST_GET, parent::getResourceKey());
         } else {
             $cards = $this['cards'];
         }

--- a/lib/omise/OmiseRefundList.php
+++ b/lib/omise/OmiseRefundList.php
@@ -26,7 +26,7 @@ class OmiseRefundList extends OmiseApiResource
      */
     public function create($params)
     {
-        $result = parent::execute($this->getUrl(), parent::REQUEST_POST, self::getResourceKey(), $params);
+        list($result, $headers) = parent::execute($this->getUrl(), parent::REQUEST_POST, self::getResourceKey(), $params);
 
         return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
     }
@@ -38,7 +38,7 @@ class OmiseRefundList extends OmiseApiResource
      */
     public function retrieve($id)
     {
-        $result = parent::execute($this->getUrl($id), parent::REQUEST_GET, self::getResourceKey());
+        list($result, $headers) = parent::execute($this->getUrl($id), parent::REQUEST_GET, self::getResourceKey());
 
         return new OmiseRefund($result, $this->_publickey, $this->_secretkey);
     }

--- a/lib/omise/exception/OmiseExceptions.php
+++ b/lib/omise/exception/OmiseExceptions.php
@@ -19,52 +19,8 @@ class OmiseException extends Exception
      */
     public static function getInstance($array)
     {
-        switch ($array['code']) {
-            case 'authentication_failure':
-                return new OmiseAuthenticationFailureException($array['message'], $array);
-
-            case 'bad_request':
-                return new OmiseBadRequestException($array['message'], $array);
-
-            case 'not_found':
-                return new OmiseNotFoundException($array['message'], $array);
-
-            case 'used_token':
-                return new OmiseUsedTokenException($array['message'], $array);
-
-            case 'invalid_card':
-                return new OmiseInvalidCardException($array['message'], $array);
-
-            case 'invalid_card_token':
-                return new OmiseInvalidCardTokenException($array['message'], $array);
-
-            case 'missing_card':
-                return new OmiseMissingCardException($array['message'], $array);
-
-            case 'invalid_charge':
-                return new OmiseInvalidChargeException($array['message'], $array);
-
-            case 'failed_capture':
-                return new OmiseFailedCaptureException($array['message'], $array);
-
-            case 'failed_fraud_check':
-                return new OmiseFailedFraudCheckException($array['message'], $array);
-
-            case 'failed_refund':
-                return new OmiseFailedRefundException($array['message'], $array);
-
-            case 'invalid_link':
-                return new OmiseInvalidLinkException($array['message'], $array);
-
-            case 'invalid_recipient':
-                return new OmiseInvalidRecipientException($array['message'], $array);
-
-            case 'invalid_bank_account':
-                return new OmiseInvalidBankAccountException($array['message'], $array);
-
-            default:
-                return new OmiseUndefinedException($array['message'], $array);
-        }
+        $exceptionClassName = 'Omise' . str_replace('_', '', ucwords($array['code'], '_')) . 'Exception';
+        return class_exists($exceptionClassName) ? new $exceptionClassName($array['message'], $array) : new OmiseUndefinedException($array['message'], $array);
     }
 
     /**

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -121,7 +121,7 @@ class OmiseApiResource extends OmiseObject
     }
 
     /**
-     * Makes a request and returns a decoded JSON data as an associative array.
+     * Makes a request and returns a decoded JSON data as an associative array, and an array of retured headers.
      *
      * @param  string $url
      * @param  string $requestMethod

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -50,7 +50,7 @@ class OmiseApiResource extends OmiseObject
     protected static function g_retrieve($clazz, $url, $publickey = null, $secretkey = null)
     {
         $resource = call_user_func(array($clazz, 'getInstance'), $clazz, $publickey, $secretkey);
-        [$result, $headers]   = $resource->execute($url, self::REQUEST_GET, $resource->getResourceKey());
+        list($result, $headers) = $resource->execute($url, self::REQUEST_GET, $resource->getResourceKey());
         $resource->refresh($result);
 
         return $resource;
@@ -72,7 +72,7 @@ class OmiseApiResource extends OmiseObject
     protected static function g_create($clazz, $url, $params, $publickey = null, $secretkey = null)
     {
         $resource = call_user_func(array($clazz, 'getInstance'), $clazz, $publickey, $secretkey);
-        [$result, $headers]   = $resource->execute($url, self::REQUEST_POST, $resource->getResourceKey(), $params);
+        list($result, $headers) = $resource->execute($url, self::REQUEST_POST, $resource->getResourceKey(), $params);
         $resource->refresh($result);
 
         return $resource;
@@ -88,7 +88,7 @@ class OmiseApiResource extends OmiseObject
      */
     protected function g_update($url, $params)
     {
-        [$result, $headers] = $this->execute($url, self::REQUEST_PATCH, $this->getResourceKey(), $params);
+        list($result, $headers) = $this->execute($url, self::REQUEST_PATCH, $this->getResourceKey(), $params);
         $this->refresh($result);
     }
 
@@ -103,7 +103,7 @@ class OmiseApiResource extends OmiseObject
      */
     protected function g_destroy($url)
     {
-        [$result, $headers] = $this->execute($url, self::REQUEST_DELETE, $this->getResourceKey());
+        list($result, $headers) = $this->execute($url, self::REQUEST_DELETE, $this->getResourceKey());
         $this->refresh($result, true);
     }
 
@@ -116,7 +116,7 @@ class OmiseApiResource extends OmiseObject
      */
     protected function g_reload($url)
     {
-        [$result, $headers] = $this->execute($url, self::REQUEST_GET, $this->getResourceKey());
+        list($result, $headers) = $this->execute($url, self::REQUEST_GET, $this->getResourceKey());
         $this->refresh($result);
     }
 
@@ -135,9 +135,9 @@ class OmiseApiResource extends OmiseObject
     {
         // If this class is execute by phpunit > get test mode.
         if (preg_match('/phpunit/', $_SERVER['SCRIPT_NAME'])) {
-            [$result, $headers] = $this->_executeTest($url, $requestMethod, $key, $params);
+            list($result, $headers) = $this->_executeTest($url, $requestMethod, $key, $params);
         } else {
-            [$result, $headers] = $this->_executeCurl($url, $requestMethod, $key, $params);
+            list($result, $headers) = $this->_executeCurl($url, $requestMethod, $key, $params);
         }
 
         // Decode the JSON response as an associative array.
@@ -247,7 +247,7 @@ class OmiseApiResource extends OmiseObject
                 mkdir($request_dir, 0777, true);
             }
 
-            [$result, $headers] = $this->_executeCurl($url, $requestMethod, $key, $params);
+            list($result, $headers) = $this->_executeCurl($url, $requestMethod, $key, $params);
 
             $f = fopen($request_url, 'w');
             if ($f) {


### PR DESCRIPTION
This PR adds the ability to be able to handle older API versions with appropriate classes...

Essentially, you can add an array to an API resource class to define which class should be used for different API versions.

In the example below - if you retrieve the OmiseCapabilities object, the class `OmiseCapabilities` will be used if the API version being used is 2019-05-29 or above, or `OmiseCapabilitiesLegacy` if the API version is below 2019-05-29 but  greater than or equal to 2017-11-02.

If the API version falls below the lowest one defined here, the main class (in this case `OmiseCapabilities` will be used. This may not be the best thing to do (maybe we should use the oldest one in the list?) - but it is an edge case that should probably never occur (if you're using this functionality you probably already have classes for all available API versions and should set them up appropriately)

```php
class OmiseCapabilities extends OmiseApiResource
{
    ...

    protected static $classNamesForAPIVersions = [
        '2019-05-29' => 'OmiseCapabilities',
        '2017-11-02' => 'OmiseCapabilitiesLegacy'
    ];
...
```

This is needed now so that we can add new payment methods to PrestaShop (internet banking, instalments, more...) without having to use the old Capability API - which we should be moving away from.

I believe Magento 2 is also still using the old Capability API