### PR TITLE
Add update method for Account

### DIFF
--- a/lib/omise/OmiseAccount.php
+++ b/lib/omise/OmiseAccount.php
@@ -20,6 +20,16 @@ class OmiseAccount extends OmiseApiResource
     /**
      * (non-PHPdoc)
      *
+     * @see OmiseApiResource::g_update()
+     */
+    public function update($params)
+    {
+        parent::g_update(self::getUrl(), $params);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
      * @see OmiseApiResource::g_reload()
      */
     public function reload()

--- a/tests/fixtures/api.omise.co/account-patch.json
+++ b/tests/fixtures/api.omise.co/account-patch.json
@@ -25,7 +25,7 @@
   "auto_activate_recipients": true,
   "chain_enabled": true,
   "zero_interest_installments": true,
-  "chain_return_uri": "https://dashboard.omise.co/test/settings",
+  "chain_return_uri": "https://www.omise.co",
   "webhook_uri": "https://omise-flask-example.herokuapp.com/webhook",
   "metadata_export_keys": {
     "charge": [

--- a/tests/omise/AccountTest.php
+++ b/tests/omise/AccountTest.php
@@ -10,6 +10,7 @@ class OmiseAccountTest extends TestConfig
     public function method_exists()
     {
         $this->assertTrue(method_exists('OmiseAccount', 'retrieve'));
+        $this->assertTrue(method_exists('OmiseAccount', 'update'));
         $this->assertTrue(method_exists('OmiseAccount', 'reload'));
         $this->assertTrue(method_exists('OmiseAccount', 'getUrl'));
     }
@@ -24,6 +25,20 @@ class OmiseAccountTest extends TestConfig
 
         $this->assertArrayHasKey('object', $account);
         $this->assertEquals('account', $account['object']);
+    }
+
+    /**
+     * @test
+     * Assert that the account is successfully updated.
+     */
+    public function update()
+    {
+        $account = OmiseAccount::retrieve();
+        $account->update(array('chain_return_uri' => 'https://www.omise.co'));
+
+        $this->assertArrayHasKey('object', $account);
+        $this->assertEquals('account', $account['object']);
+        $this->assertEquals('https://www.omise.co', $account['chain_return_uri']);
     }
 
     /**


### PR DESCRIPTION
### Summary
- [x] Add update method for Account ([Omise doc](https://www.omise.co/account-api#update))
- [x] Add test

### QA
You should be able to update your account information.

1. Retrieve your account
`$account = OmiseAccount::retrieve();`

2. Update your account
`$account->update(array('chain_return_uri' => 'https://www.test.com'));`

3. Check whether your account has been updated
`$account['chain_return_uri'];`