### PR TITLE
Add destroy method for Link

### DIFF
--- a/lib/omise/OmiseLink.php
+++ b/lib/omise/OmiseLink.php
@@ -61,6 +61,26 @@ class OmiseLink extends OmiseApiResource
     }
 
     /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_destroy()
+     */
+    public function destroy()
+    {
+        parent::g_destroy(self::getUrl($this['id']));
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::isDestroyed()
+     */
+    public function isDestroyed()
+    {
+        return parent::isDestroyed();
+    }
+
+    /**
      * @param  string $id
      *
      * @return string

--- a/tests/fixtures/api.omise.co/links/link_test_56bsanpa365jnlbc7rt-delete.json
+++ b/tests/fixtures/api.omise.co/links/link_test_56bsanpa365jnlbc7rt-delete.json
@@ -24,5 +24,5 @@
   },
   "payment_uri": "https://link.omise.co/B86D8AB5",
   "created": "2016-12-14T16:01:21Z",
-  "deleted": false
+  "deleted": true
 }

--- a/tests/omise/LinkTest.php
+++ b/tests/omise/LinkTest.php
@@ -11,6 +11,8 @@ class LinkTest extends TestConfig
     {
         $this->assertTrue(method_exists('OmiseLink', 'retrieve'));
         $this->assertTrue(method_exists('OmiseLink', 'create'));
+        $this->assertTrue(method_exists('OmiseLink', 'destroy'));
+        $this->assertTrue(method_exists('OmiseLink', 'isDestroyed'));
         $this->assertTrue(method_exists('OmiseLink', 'getUrl'));
     }
 
@@ -50,6 +52,18 @@ class LinkTest extends TestConfig
 
         $this->assertArrayHasKey('object', $link);
         $this->assertEquals('link', $link['object']);
+    }
+
+    /**
+     * @test
+     * Assert that the link is successfully destroyed.
+     */
+    public function destroy()
+    {
+        $link = OmiseLink::retrieve('link_test_56bsanpa365jnlbc7rt');
+        $link->destroy();
+
+        $this->assertTrue($link->isDestroyed());
     }
 
     /**


### PR DESCRIPTION
### Summary
- [x] Add destroy method for Link ([Omise doc](https://www.omise.co/links-api#destroy))
- [x] Add test

### QA
You should be able to destroy a link.

1. Retrieve a link
`$link = OmiseLink::retrieve('link_test_5mukm8560fx6jgk0ya5');`

2. Destroy the link
`$link->destroy();`

3. Check whether the link has been destroyed
`$link->isDestroyed();`