### PR TITLE
Add accept method for Dispute

### DIFF
--- a/lib/omise/OmiseDispute.php
+++ b/lib/omise/OmiseDispute.php
@@ -57,6 +57,16 @@ class OmiseDispute extends OmiseApiResource
     }
 
     /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_update()
+     */
+    public function accept()
+    {
+        parent::g_update(self::getUrl($this['id']) . '/accept');
+    }
+
+    /**
      * Generate request url.
      *
      * @param  string $id

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -57,7 +57,7 @@ class OmiseApiResource extends OmiseObject
     }
 
     /**
-     * Creates the resource with given parameters.in an associative array.
+     * Creates the resource with given parameters in an associative array.
      *
      * @param  string $clazz
      * @param  string $url
@@ -86,7 +86,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @throws Exception|OmiseException
      */
-    protected function g_update($url, $params)
+    protected function g_update($url, $params = null)
     {
         $result = $this->execute($url, self::REQUEST_PATCH, $this->getResourceKey(), $params);
         $this->refresh($result);

--- a/tests/fixtures/api.omise.co/disputes/dspt_test_4zgf15h89w8t775kcm8/accept-patch.json
+++ b/tests/fixtures/api.omise.co/disputes/dspt_test_4zgf15h89w8t775kcm8/accept-patch.json
@@ -1,0 +1,12 @@
+{
+  "object": "dispute",
+  "id": "dspt_test_4zgf15h89w8t775kcm8",
+  "livemode": false,
+  "location": "/disputes/dspt_test_4zgf15h89w8t775kcm8",
+  "amount": 100000,
+  "currency": "thb",
+  "status": "lost",
+  "message": "This is an unauthorized transaction",
+  "charge": "chrg_test_4zgcsiv4s6ewsy8nrw3",
+  "created": "2015-03-23T05:24:39Z"
+}

--- a/tests/omise/DisputeTest.php
+++ b/tests/omise/DisputeTest.php
@@ -12,6 +12,7 @@ class OmiseDisputeTest extends TestConfig
         $this->assertTrue(method_exists('OmiseDispute', 'retrieve'));
         $this->assertTrue(method_exists('OmiseDispute', 'reload'));
         $this->assertTrue(method_exists('OmiseDispute', 'update'));
+        $this->assertTrue(method_exists('OmiseDispute', 'accept'));
         $this->assertTrue(method_exists('OmiseDispute', 'getUrl'));
     }
 
@@ -93,6 +94,20 @@ class OmiseDisputeTest extends TestConfig
 
         $this->assertArrayHasKey('object', $dispute);
         $this->assertEquals('dispute', $dispute['object']);
+    }
+
+    /**
+     * @test
+     * Assert that the dispute is successfully accepted.
+     */
+    public function accept()
+    {
+        $dispute = OmiseDispute::retrieve('dspt_test_4zgf15h89w8t775kcm8');
+        $dispute->accept();
+
+        $this->assertArrayHasKey('object', $dispute);
+        $this->assertEquals('dispute', $dispute['object']);
+        $this->assertEquals('lost', $dispute['status']);
     }
 
     /**


### PR DESCRIPTION
### Summary
- [x] Add accept method for Dispute ([Omise doc](https://www.omise.co/disputes-api#accept))
- [x] Add test

### QA
You should be able to accept a dispute.

1. Retrieve a  dispute
`$dispute = OmiseDispute::retrieve('dspt_test_5munz1609ullh5toqgh');`

2. Accept the dispute
`$dispute->accept();`

3. Check whether the dispute has been accepted, the status should be `lost`
`$dispute['status'];`