### PR TITLE
Add Chain API

### DIFF
--- a/lib/Omise.php
+++ b/lib/Omise.php
@@ -12,6 +12,7 @@ require_once dirname(__FILE__).'/omise/OmiseBalance.php';
 require_once dirname(__FILE__).'/omise/OmiseCapabilities.php';
 require_once dirname(__FILE__).'/omise/OmiseCard.php';
 require_once dirname(__FILE__).'/omise/OmiseCardList.php';
+require_once dirname(__FILE__).'/omise/OmiseChain.php';
 require_once dirname(__FILE__).'/omise/OmiseDispute.php';
 require_once dirname(__FILE__).'/omise/OmiseEvent.php';
 require_once dirname(__FILE__).'/omise/OmiseForex.php';

--- a/lib/omise/OmiseChain.php
+++ b/lib/omise/OmiseChain.php
@@ -1,0 +1,56 @@
+<?php
+
+class OmiseChain extends OmiseApiResource
+{
+    const ENDPOINT = 'chains';
+
+    /**
+     * Retrieves a sub-merchant chain.
+     *
+     * @param  string $id
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseChain
+     */
+    public static function retrieve($id = '', $publickey = null, $secretkey = null)
+    {
+        return parent::g_retrieve(get_class(), self::getUrl($id), $publickey, $secretkey);
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_reload()
+     */
+    public function reload()
+    {
+        if ($this['object'] === 'event') {
+            parent::g_reload(self::getUrl($this['id']));
+        } else {
+            parent::g_reload(self::getUrl());
+        }
+    }
+
+    /**
+     * (non-PHPdoc)
+     *
+     * @see OmiseApiResource::g_revoke()
+     */
+    public function revoke()
+    {
+        parent::g_revoke(self::getUrl($this['id']) . '/revoke');
+    }
+
+    /**
+     * Generate request url.
+     *
+     * @param  string $id
+     *
+     * @return string
+     */
+    private static function getUrl($id = '')
+    {
+        return OMISE_API_URL.self::ENDPOINT.'/'.$id;
+    }
+}

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -108,6 +108,19 @@ class OmiseApiResource extends OmiseObject
     }
 
     /**
+     * Revokes the resource.
+     *
+     * @param  string $url
+     *
+     * @throws Exception|OmiseException
+     */
+    protected function g_revoke($url)
+    {
+        $result = $this->execute($url, self::REQUEST_POST, $this->getResourceKey());
+        $this->refresh($result, true);
+    }
+
+    /**
      * Reloads the resource with latest data.
      *
      * @param  string $url

--- a/tests/fixtures/api.omise.co/chains-get.json
+++ b/tests/fixtures/api.omise.co/chains-get.json
@@ -1,0 +1,32 @@
+{
+  "object": "list",
+  "data": [
+    {
+      "object": "chain",
+      "id": "acch_test_no1t4tnemucod0e51mo",
+      "livemode": false,
+      "location": "/chains/acch_test_no1t4tnemucod0e51mo",
+      "created_at": "2019-04-23T07:44:31Z",
+      "revoked": false,
+      "key": "ckey_test_no1t4tnemucod0e51mo",
+      "email": "somchai.prasert@esimo.co"
+    },
+    {
+      "object": "chain",
+      "id": "acch_test_no1t4tnemucadsfe51m2",
+      "livemode": false,
+      "location": "/chains/acch_test_no1t4tnemucadsfe51m2",
+      "created_at": "2019-04-24T07:44:31Z",
+      "revoked": false,
+      "key": "ckey_test_no1t4tnemucadsfe51m2",
+      "email": "somchai.pradith@esimo.co"
+    }
+  ],
+  "limit": 20,
+  "offset": 0,
+  "total": 2,
+  "location": null,
+  "order": "chronological",
+  "from": "1970-01-01T00:00:00Z",
+  "to": "2021-02-14T11:22:13Z"
+}

--- a/tests/fixtures/api.omise.co/chains/acch_test_no1t4tnemucod0e51mo-get.json
+++ b/tests/fixtures/api.omise.co/chains/acch_test_no1t4tnemucod0e51mo-get.json
@@ -1,0 +1,10 @@
+{
+  "object": "chain",
+  "id": "acch_test_no1t4tnemucod0e51mo",
+  "livemode": false,
+  "location": "/chains/acch_test_no1t4tnemucod0e51mo",
+  "created_at": "2019-04-23T07:44:31Z",
+  "revoked": false,
+  "key": "ckey_test_no1t4tnemucod0e51mo",
+  "email": "somchai.prasert@esimo.co"
+}

--- a/tests/fixtures/api.omise.co/chains/acch_test_no1t4tnemucod0e51mo/revoke-post.json
+++ b/tests/fixtures/api.omise.co/chains/acch_test_no1t4tnemucod0e51mo/revoke-post.json
@@ -1,0 +1,10 @@
+{
+  "object": "chain",
+  "id": "acch_test_no1t4tnemucod0e51mo",
+  "livemode": false,
+  "location": "/chains/acch_test_no1t4tnemucod0e51mo",
+  "created_at": "2019-04-23T07:44:31Z",
+  "revoked": true,
+  "key": "ckey_test_no1t4tnemucod0e51mo",
+  "email": "somchai.prasert@esimo.co"
+}

--- a/tests/omise/ChainTest.php
+++ b/tests/omise/ChainTest.php
@@ -1,0 +1,81 @@
+<?php
+require_once dirname(__FILE__).'/TestConfig.php';
+
+class ChainTest extends TestConfig
+{
+    /**
+     * @test
+     * Assert that OmiseChain class contains the methods below.
+     */
+    public function method_exists()
+    {
+        $this->assertTrue(method_exists('OmiseChain', 'retrieve'));
+        $this->assertTrue(method_exists('OmiseChain', 'reload'));
+        $this->assertTrue(method_exists('OmiseChain', 'revoke'));
+        $this->assertTrue(method_exists('OmiseChain', 'getUrl'));
+    }
+
+    /**
+     * @test
+     * Assert that a list of sub-merchant chains could be successfully retrieved.
+     */
+    public function retrieve_chain_list()
+    {
+        $chain = OmiseChain::retrieve();
+
+        $this->assertArrayHasKey('object', $chain);
+        $this->assertEquals('list', $chain['object']);
+    }
+
+    /**
+     * @test
+     * Assert that a sub-merchant chain could be successfully retrieved.
+     */
+    public function retrieve_chain_id()
+    {
+        $chain = OmiseChain::retrieve('acch_test_no1t4tnemucod0e51mo');
+
+        $this->assertArrayHasKey('object', $chain);
+        $this->assertEquals('acch_test_no1t4tnemucod0e51mo', $chain['id']);
+    }
+
+    /**
+     * @test
+     * Assert that a list of sub-merchant chains could be successfully reloaded.
+     */
+    public function reload_chain_list()
+    {
+        $chain = OmiseChain::retrieve();
+        $chain->reload();
+
+        $this->assertArrayHasKey('object', $chain);
+        $this->assertEquals('list', $chain['object']);
+    }
+
+    /**
+     * @test
+     * Assert that a sub-merchant chain could be successfully reloaded.
+     */
+    public function reload_chain_id()
+    {
+        $chain = OmiseChain::retrieve('acch_test_no1t4tnemucod0e51mo');
+        $chain->reload();
+
+        $this->assertArrayHasKey('object', $chain);
+        $this->assertEquals('acch_test_no1t4tnemucod0e51mo', $chain['id']);
+    }
+
+    /**
+     * @test
+     * Assert that a sub-merchant chain could be successfully revoked.
+     */
+    public function revoke_chain()
+    {
+        $chain = OmiseChain::retrieve('acch_test_no1t4tnemucod0e51mo');
+        $chain->revoke();
+
+        $this->assertArrayHasKey('object', $chain);
+        $this->assertEquals('acch_test_no1t4tnemucod0e51mo', $chain['id']);
+        $this->assertTrue($chain['revoked']);
+    }
+}

--- a/tests/omise/ClassExistsTest.php
+++ b/tests/omise/ClassExistsTest.php
@@ -19,6 +19,7 @@ class ClassExistsTest extends PHPUnit_Framework_TestCase
         $this->assertTrue(class_exists('OmiseBalance'));
         $this->assertTrue(class_exists('OmiseCard'));
         $this->assertTrue(class_exists('OmiseCardList'));
+        $this->assertTrue(class_exists('OmiseChain'));
         $this->assertTrue(class_exists('OmiseCharge'));
         $this->assertTrue(class_exists('OmiseCustomer'));
         $this->assertTrue(class_exists('OmiseDispute'));


### PR DESCRIPTION
### Summary
- [x] Add Chain API ([Omise doc](https://www.omise.co/chains-api))
- [x] Add tests

### QA
You should be able to do the following actions.

- List sub-merchant chains
`$chains = OmiseChain::retrieve();`

- Retrieve a sub-merchant chain
`$chain = OmiseChain::retrieve('acch_test_5lals6ot3vlz6lsnfhn');`

- Reload a sub-merchant chain
`$chain->reload();`

- Revoke a sub-merchant chain
`$chain->revoke();`