### PR TITLE
[Plugins 250] : Update codes to compatible with php 8

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['5.6', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.4', '8.1']
     steps:
     - uses: actions/checkout@v2
 

--- a/lib/omise/OmiseCapabilities.php
+++ b/lib/omise/OmiseCapabilities.php
@@ -178,8 +178,8 @@ class OmiseCapabilities extends OmiseApiResource
      *
      * @return string
      */
-    protected function getResourceKey()
+    protected static function getResourceKey()
     {
-        return $this->_publickey;
+        return parent::getResourceKey();
     }
 }

--- a/lib/omise/OmiseCard.php
+++ b/lib/omise/OmiseCard.php
@@ -57,7 +57,7 @@ class OmiseCard extends OmiseApiResource
      *
      * @see OmiseApiResource::isDestroyed()
      */
-    public function isDestroyed()
+    public static function isDestroyed()
     {
         return parent::isDestroyed();
     }

--- a/lib/omise/OmiseCharge.php
+++ b/lib/omise/OmiseCharge.php
@@ -161,8 +161,7 @@ class OmiseCharge extends OmiseApiResource
         if (is_array($options)) {
             $options = '?' . http_build_query($options);
         }
-
-        return parent::g_retrieve('OmiseScheduleList', self::getUrl('schedules' . $options), $publickey, $secretkey);
+        return OmiseScheduleList::g_retrieve('OmiseScheduleList', self::getUrl('schedules' . $options), $publickey, $secretkey);
     }
 
     /**

--- a/lib/omise/OmiseCustomer.php
+++ b/lib/omise/OmiseCustomer.php
@@ -85,7 +85,7 @@ class OmiseCustomer extends OmiseApiResource
      *
      * @see OmiseApiResource::isDestroyed()
      */
-    public function isDestroyed()
+    public static function isDestroyed()
     {
         return parent::isDestroyed();
     }
@@ -133,8 +133,7 @@ class OmiseCustomer extends OmiseApiResource
             if (is_array($options)) {
                 $options = '?' . http_build_query($options);
             }
-
-            return parent::g_retrieve('OmiseScheduleList', self::getUrl($this['id'] . '/schedules' . $options), $this->_publickey, $this->_secretkey);
+            return OmiseScheduleList::g_retrieve('OmiseScheduleList', self::getUrl($this['id'] . '/schedules' . $options), $this->_publickey, $this->_secretkey);
         }
     }
 

--- a/lib/omise/OmiseDispute.php
+++ b/lib/omise/OmiseDispute.php
@@ -4,6 +4,22 @@ class OmiseDispute extends OmiseApiResource
 {
     const ENDPOINT = 'disputes';
 
+
+    /**
+     * Creates a new dispute.
+     *
+     * @param  array  $params
+     * @param  string $publickey
+     * @param  string $secretkey
+     *
+     * @return OmiseDispute
+     */
+    public static function create($charge, $params, $publickey = null, $secretkey = null)
+    {
+        $url = OMISE_API_URL. 'charges/' . $charge['id'] .'/' . self::ENDPOINT;
+        return parent::g_create(get_class(), $url, $params, $publickey, $secretkey);
+    }
+
     /**
      * Retrieves a dispute.
      *

--- a/lib/omise/OmiseLink.php
+++ b/lib/omise/OmiseLink.php
@@ -75,7 +75,7 @@ class OmiseLink extends OmiseApiResource
      *
      * @see OmiseApiResource::isDestroyed()
      */
-    public function isDestroyed()
+    public static function isDestroyed()
     {
         return parent::isDestroyed();
     }

--- a/lib/omise/OmiseRecipient.php
+++ b/lib/omise/OmiseRecipient.php
@@ -71,7 +71,7 @@ class OmiseRecipient extends OmiseApiResource
      *
      * @see OmiseApiResource::isDestroyed()
      */
-    public function isDestroyed()
+    public static function isDestroyed()
     {
         return parent::isDestroyed();
     }
@@ -103,8 +103,8 @@ class OmiseRecipient extends OmiseApiResource
             if (is_array($options)) {
                 $options = '?' . http_build_query($options);
             }
-
-            return parent::g_retrieve('OmiseScheduleList', self::getUrl($this['id'] . '/schedules' . $options), $this->_publickey, $this->_secretkey);
+            
+            return OmiseScheduleList::g_retrieve('OmiseScheduleList', self::getUrl($this['id'] . '/schedules' . $options), $this->_publickey, $this->_secretkey);
         }
     }
 

--- a/lib/omise/OmiseSchedule.php
+++ b/lib/omise/OmiseSchedule.php
@@ -56,7 +56,7 @@ class OmiseSchedule extends OmiseApiResource
                 $options = '?' . http_build_query($options);
             }
 
-            return parent::g_retrieve('OmiseOccurrenceList', self::getUrl($this['id'] . '/occurrences' . $options), $this->_publickey, $this->_secretkey);
+            return OmiseOccurrenceList::g_retrieve('OmiseOccurrenceList', self::getUrl($this['id'] . '/occurrences' . $options), $this->_publickey, $this->_secretkey);
         }
     }
 
@@ -73,7 +73,7 @@ class OmiseSchedule extends OmiseApiResource
      *
      * @see    OmiseApiResource::isDestroyed()
      */
-    public function isDestroyed()
+    public static function isDestroyed()
     {
         return parent::isDestroyed();
     }

--- a/lib/omise/OmiseSearch.php
+++ b/lib/omise/OmiseSearch.php
@@ -37,22 +37,10 @@ class OmiseSearch extends OmiseApiResource
      */
     public static function scope($scope, $publickey = null, $secretkey = null)
     {
-        return new OmiseSearch($scope, $publickey, $secretkey);
-    }
-
-    /**
-     * Create an instance of `OmiseSearch` with the given scope.
-     *
-     * This constructor is `protected` thus not intended to be used directly.
-     *
-     * @param string $scope  See supported scope at [Search API](https://www.omise.co/search-api) page.
-     * @param string $publickey
-     * @param string $secretkey
-     */
-    protected function __construct($scope, $publickey, $secretkey)
-    {
-        parent::__construct($publickey, $secretkey);
-        $this->mergeAttributes('scope', $scope);
+       
+        $resouce = self::getInstance($publickey = null, $secretkey = null);
+        $resouce->mergeAttributes('scope', $scope);
+        return $resouce;
     }
 
     /**

--- a/lib/omise/OmiseTransfer.php
+++ b/lib/omise/OmiseTransfer.php
@@ -106,8 +106,7 @@ class OmiseTransfer extends OmiseApiResource
         if (is_array($options)) {
             $options = '?' . http_build_query($options);
         }
-
-        return parent::g_retrieve('OmiseScheduleList', self::getUrl('schedules' . $options), $publickey, $secretkey);
+        return OmiseScheduleList::g_retrieve('OmiseScheduleList', self::getUrl('schedules' . $options), $publickey, $secretkey);
     }
 
     /**
@@ -125,7 +124,7 @@ class OmiseTransfer extends OmiseApiResource
      *
      * @see OmiseApiResource::isDestroyed()
      */
-    public function isDestroyed()
+    public static function isDestroyed()
     {
         return parent::isDestroyed();
     }

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -1,8 +1,8 @@
 <?php
 
 define('OMISE_PHP_LIB_VERSION', '2.13.0');
-define('OMISE_API_URL', 'https://api.omise.co/');
-define('OMISE_VAULT_URL', 'https://vault.omise.co/');
+@define('OMISE_API_URL', 'https://api.omise.co/');
+@define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
 class OmiseApiResource extends OmiseObject
 {
@@ -17,6 +17,10 @@ class OmiseApiResource extends OmiseObject
     private $OMISE_TIMEOUT = 60;
 
     protected static $instances  = [];
+
+    private static $classesToUsePublicKey = [
+        OmiseToken::class,
+    ];
 
     /**
      * Returns an instance of the class given in $clazz or raise an error.
@@ -359,6 +363,9 @@ class OmiseApiResource extends OmiseObject
     protected static function getResourceKey()
     {
         $resource = self::getInstance();
+        if(in_array(get_class($resource), self::$classesToUsePublicKey)) {
+            return $resource->_publickey;
+        }
         return $resource->_secretkey;
     }
 }

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -86,7 +86,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @throws Exception|OmiseException
      */
-    protected function g_update($url, $params = null)
+    protected static function g_update($url, $params = null)
     {
         $result = $this->execute($url, self::REQUEST_PATCH, $this->getResourceKey(), $params);
         $this->refresh($result);
@@ -101,7 +101,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @return OmiseApiResource
      */
-    protected function g_expire($url)
+    protected static function g_expire($url)
     {
         $result = $this->execute($url, self::REQUEST_POST, $this->getResourceKey());
         $this->refresh($result, true);
@@ -116,7 +116,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @return OmiseApiResource
      */
-    protected function g_destroy($url)
+    protected static function g_destroy($url)
     {
         $result = $this->execute($url, self::REQUEST_DELETE, $this->getResourceKey());
         $this->refresh($result, true);
@@ -129,7 +129,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @throws Exception|OmiseException
      */
-    protected function g_revoke($url)
+    protected static function g_revoke($url)
     {
         $result = $this->execute($url, self::REQUEST_POST, $this->getResourceKey());
         $this->refresh($result, true);
@@ -142,7 +142,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @throws Exception|OmiseException
      */
-    protected function g_reload($url)
+    protected static function g_reload($url)
     {
         $result = $this->execute($url, self::REQUEST_GET, $this->getResourceKey());
         $this->refresh($result);
@@ -159,7 +159,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @return array
      */
-    protected function execute($url, $requestMethod, $key, $params = null)
+    protected static function execute($url, $requestMethod, $key, $params = null)
     {
         // If this class is execute by phpunit > get test mode.
         if (preg_match('/phpunit/', $_SERVER['SCRIPT_NAME'])) {
@@ -191,7 +191,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @return boolean
      */
-    protected function isValidAPIResponse($array)
+    protected static function isValidAPIResponse($array)
     {
         return count($array) && isset($array['object']);
     }
@@ -342,7 +342,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @return bool|null
      */
-    protected function isDestroyed()
+    protected static function isDestroyed()
     {
         return $this['deleted'];
     }
@@ -352,7 +352,7 @@ class OmiseApiResource extends OmiseObject
      *
      * @return string
      */
-    protected function getResourceKey()
+    protected static function getResourceKey()
     {
         return $this->_secretkey;
     }

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -1,8 +1,8 @@
 <?php
 
 define('OMISE_PHP_LIB_VERSION', '2.13.0');
-@define('OMISE_API_URL', 'https://api.omise.co/');
-@define('OMISE_VAULT_URL', 'https://vault.omise.co/');
+define('OMISE_API_URL', 'https://api.omise.co/');
+define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
 class OmiseApiResource extends OmiseObject
 {
@@ -200,7 +200,7 @@ class OmiseApiResource extends OmiseObject
      */
     protected static function isValidAPIResponse($array)
     {
-        return count($array) && isset($array['object']);
+        return $array && count($array) && isset($array['object']);
     }
 
     /**

--- a/lib/omise/res/OmiseVaultResource.php
+++ b/lib/omise/res/OmiseVaultResource.php
@@ -7,8 +7,8 @@ class OmiseVaultResource extends OmiseApiResource
      *
      * @return string
      */
-    protected function getResourceKey()
+    protected static function getResourceKey()
     {
-        return $this->_publickey;
+        return parent::getResourceKey();
     }
 }

--- a/lib/omise/res/obj/OmiseObject.php
+++ b/lib/omise/res/obj/OmiseObject.php
@@ -18,6 +18,7 @@ class OmiseObject implements ArrayAccess, Iterator, Countable
      * @param string $publickey
      * @param string $secretkey
      */
+    #[\ReturnTypeWillChange]
     protected function __construct($publickey = null, $secretkey = null)
     {
         if ($publickey !== null) {
@@ -41,6 +42,7 @@ class OmiseObject implements ArrayAccess, Iterator, Countable
      * @param array   $values
      * @param boolean $clear
      */
+    #[\ReturnTypeWillChange]
     public function refresh($values, $clear = false)
     {
         if ($clear) {
@@ -51,53 +53,63 @@ class OmiseObject implements ArrayAccess, Iterator, Countable
     }
 
     // Override methods of ArrayAccess
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         $this->_values[$key] = $value;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return isset($this->_values[$key]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->_values[$key]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return isset($this->_values[$key]) ? $this->_values[$key] : null;
     }
 
     // Override methods of Iterator
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->_values);
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->_values);
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->_values);
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         return next($this->_values);
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return ($this->current() !== false);
     }
 
     // Override methods of Countable
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->_values);

--- a/lib/omise/res/obj/OmiseObject.php
+++ b/lib/omise/res/obj/OmiseObject.php
@@ -49,7 +49,7 @@ class OmiseObject implements ArrayAccess, Iterator, Countable
             $this->_values = array();
         }
 
-        $this->_values = array_merge($this->_values, $values);
+        $this->_values = array_merge($this->_values ?? [], $values ?? []);
     }
 
     // Override methods of ArrayAccess

--- a/lib/omise/res/obj/OmiseObject.php
+++ b/lib/omise/res/obj/OmiseObject.php
@@ -24,12 +24,18 @@ class OmiseObject implements ArrayAccess, Iterator, Countable
         if ($publickey !== null) {
             $this->_publickey = $publickey;
         } else {
+            if (!defined('OMISE_PUBLIC_KEY')) {
+                define('OMISE_PUBLIC_KEY', 'pkey');
+            }
             $this->_publickey = OMISE_PUBLIC_KEY;
         }
 
         if ($secretkey !== null) {
             $this->_secretkey = $secretkey;
         } else {
+            if (!defined('OMISE_SECRET_KEY')) {
+                define('OMISE_SECRET_KEY', 'skey');
+            }
             $this->_secretkey = OMISE_SECRET_KEY;
         }
 

--- a/lib/omise/res/obj/OmiseObject.php
+++ b/lib/omise/res/obj/OmiseObject.php
@@ -120,4 +120,10 @@ class OmiseObject implements ArrayAccess, Iterator, Countable
     {
         return count($this->_values);
     }
+
+    #[\ReturnTypeWillChange]
+    public function toArray()
+    {
+        return $this->_values;
+    }
 }


### PR DESCRIPTION
#### 1. Update codes to compatible with php 8

- Fix code to compatible with php 8
- Use singleton pattern to get instance in OmiseApiResource class
- Convert non-static methods into static methods
- added  #[\ReturnTypeWillChange] in OmiseObject Iterator class

**Related information**:
[#SHOPIFYAPP-268](https://opn-ooo.atlassian.net/browse/SHOPIFYAPP-268)

**🔧 Environments:**
- PHP Version >= 8.0