### PR TITLE
Count actual returned data objects in OmiseObject, not number of fields returned

### DIFF
--- a/lib/omise/res/obj/OmiseObject.php
+++ b/lib/omise/res/obj/OmiseObject.php
@@ -121,7 +121,7 @@ class OmiseObject implements ArrayAccess, Iterator, Countable
     #[\ReturnTypeWillChange]
     public function count()
     {
-        return count($this->_values);
+        return count($this->_values['data']);
     }
 
     #[\ReturnTypeWillChange]


### PR DESCRIPTION


#### Objective

When calling `count()` on the result of the API call, it always returns 9 for me (when calling OmiseCharge). Return the actual number of data objects instead.

#### Description of change

![image](https://github.com/omise/omise-php/assets/1620454/6f2db501-33ba-4889-abb9-85144915ce89)


#### How Has This Been Tested

Not tested. May break other requests.

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

#### Additional Notes

None