### PR TITLE
Add #[AllowDynamicProperties] to not emit deprecation notice.

### DIFF
--- a/.github/workflows/coding-standard-check.yml
+++ b/.github/workflows/coding-standard-check.yml
@@ -35,6 +35,8 @@ jobs:
           - "7.4"
           - "8.0"
           - "8.1"
+          - "8.2"
+          - "8.3"
 
     steps:
       - uses: actions/checkout@master

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -4,6 +4,7 @@ define('OMISE_PHP_LIB_VERSION', '2.17.0');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
+#[AllowDynamicProperties]
 class OmiseApiResource extends OmiseObject
 {
     // Request methods

--- a/lib/omise/res/OmiseApiResource.php
+++ b/lib/omise/res/OmiseApiResource.php
@@ -4,7 +4,7 @@ define('OMISE_PHP_LIB_VERSION', '2.17.0');
 define('OMISE_API_URL', 'https://api.omise.co/');
 define('OMISE_VAULT_URL', 'https://vault.omise.co/');
 
-#[AllowDynamicProperties]
+#[\AllowDynamicProperties]
 class OmiseApiResource extends OmiseObject
 {
     // Request methods


### PR DESCRIPTION
## Description

Suppress deprecation notices for dynamic properties introduced in PHP 8.2 by adding #[AllowDynamicProperties].

## Rollback procedure

`default rollback procedure`
