### PR TITLE
Fix PHP 8.5 curl_close() deprecation in OmiseHttpExecutor.

### DIFF
--- a/lib/omise/http/OmiseHttpExecutor.php
+++ b/lib/omise/http/OmiseHttpExecutor.php
@@ -14,15 +14,26 @@ class OmiseHttpExecutor implements OmiseHttpExecutorInterface
         // Make a request or thrown an exception.
         if (($result = curl_exec($ch)) === false) {
             $error = curl_error($ch);
-            curl_close($ch);
+            $this->closeCurlHandle($ch);
 
             throw new Exception($error);
         }
 
-        // Close.
-        curl_close($ch);
+        $this->closeCurlHandle($ch);
 
         return $result;
+    }
+
+    /**
+     * curl_close() is deprecated since PHP 8.5 (no-op since 8.0) but still required on PHP 7.x.
+     *
+     * @param resource|\CurlHandle $ch
+     */
+    private function closeCurlHandle($ch): void
+    {
+        if (\PHP_VERSION_ID < 80000) {
+            curl_close($ch);
+        }
     }
 
     /**

--- a/tests/unit/http/OmiseHttpExecutorTest.php
+++ b/tests/unit/http/OmiseHttpExecutorTest.php
@@ -116,6 +116,8 @@ class OmiseHttpExecutorTest extends UnitTestCase
             ->once()
             ->with(Mockery::any(), Mockery::on($assertCurlOptsFn));
         Functions\expect('curl_exec')->andReturnUsing($curlFn);
-        Functions\expect('curl_close')->once();
+        if (\PHP_VERSION_ID < 80000) {
+            Functions\expect('curl_close')->once();
+        }
     }
 }


### PR DESCRIPTION
Skip curl_close() on PHP 8.0+ where handles are auto-closed, while keeping explicit cleanup on PHP 7.x for backward compatibility.